### PR TITLE
Refactor deterministic equivalent code

### DIFF
--- a/power_law_rf/deterministic_equivalent.py
+++ b/power_law_rf/deterministic_equivalent.py
@@ -3,7 +3,8 @@ import jax.numpy as jnp
 import scipy as sp
 import time
 
-def theory_limit_loss(alpha, beta,V,D):
+
+def theory_limit_loss(alpha, beta, V, D):
     """Generate the 'exact' finite V, D expression the residual risk level (risk at time infinity)
 
     Parameters
@@ -17,18 +18,18 @@ def theory_limit_loss(alpha, beta,V,D):
     """
     cstar = 0.0
     if 2*alpha >= 1.0:
-        kappa = theory_kappa(alpha,V,D)
-        cstar = jnp.sum( jnp.arange(1,V,1.0)**(-2.0*(beta+alpha))/( jnp.arange(1,V,1.0)**(-2.0*(alpha))*kappa*(D**(2*alpha)) + 1.0))
+        kappa = theory_kappa(alpha, V, D)
+        cstar = jnp.sum(jnp.arange(1, V, 1.0) ** (-2.0 * (beta + alpha)) / (jnp.arange(1, V, 1.0) ** (-2.0 * (alpha)) * kappa * (D ** (2 * alpha)) + 1.0))
 
     if 2*alpha < 1.0:
-        #tau = D/jnp.sum( jnp.arange(1,V,1.0)**(-2.0*alpha))
         tau = theory_tau(alpha,V,D)
-        cstar = jnp.sum( jnp.arange(1,V,1.0)**(-2.0*(beta+alpha))/( jnp.arange(1,V,1.0)**(-2.0*(alpha))*tau + 1.0))
+        cstar = jnp.sum(jnp.arange(1, V, 1.0) ** (-2.0 * (beta + alpha)) / (jnp.arange(1, V, 1.0) ** (-2.0 * (alpha)) * tau + 1.0))
 
 
     return cstar
 
-def theory_kappa(alpha, V,D):
+
+def theory_kappa(alpha, V, D):
     """Generate coefficient kappa with finite sample corrections.
     Parameters
     ----------
@@ -43,19 +44,20 @@ def theory_kappa(alpha, V,D):
     """
 
     TMAX = 1000.0
-    c, _ = sp.integrate.quad(lambda x: 1.0/(1.0+x**(2*alpha)),0.0,TMAX)
-    kappa=c**(-2.0*alpha)
+    c, _ = sp.integrate.quad(lambda x: 1.0/ (1.0 + x ** (2 * alpha)), 0.0, TMAX)
+    kappa = c ** (-2.0 * alpha)
 
-    kappa_it = lambda k : sp.integrate.quad(lambda x: 1.0/(k+x**(2*alpha)),0.0,V/D)[0]
+    kappa_it = lambda k : sp.integrate.quad(lambda x: 1.0 / (k + x ** (2 * alpha)), 0.0, V / D)[0]
     eps = 10E-4
     error = 1.0
     while error > eps:
-        kappa1 = 1.0/kappa_it(kappa)
-        error = abs(kappa1/kappa - 1.0)
+        kappa1 = 1.0 / kappa_it(kappa)
+        error = abs(kappa1 / kappa - 1.0)
         kappa = kappa1
     return kappa
 
-def theory_tau(alpha, V,D):
+
+def theory_tau(alpha, V, D):
     """Generate coefficient tau with finite sample corrections.
     Parameters
     ----------
@@ -69,16 +71,15 @@ def theory_tau(alpha, V,D):
     theoretical prediction for kappa parameter
     """
 
-    tau_it = lambda k : jnp.sum( 1.0/(D*(jnp.arange(1,V,1)**(2*alpha) +k)))
+    tau_it = lambda k : jnp.sum(1.0 / (D * (jnp.arange(1, V, 1) ** (2 * alpha) + k)))
     tau = tau_it(0)
     eps = 10E-4
     error = 1.0
     while error > eps:
-        tau1 = 1.0/tau_it(tau)
-        error = abs(tau1/tau - 1.0)
+        tau1 = 1.0 / tau_it(tau)
+        error = abs(tau1 / tau - 1.0)
         tau = tau1
     return tau
-
 
 
 def theory_lambda_min(alpha):
@@ -95,18 +96,18 @@ def theory_lambda_min(alpha):
   """
 
   TMAX = 1000.0
-  c, _ = sp.integrate.quad(lambda x: 1.0/(1.0+x**(2*alpha)),0.0,TMAX)
+  c, _ = sp.integrate.quad(lambda x: 1.0 / (1.0 + x ** (2 * alpha)), 0.0, TMAX)
 
-  return (1/(2*alpha-1))*((2*alpha/(2*alpha-1)/c)**(-2*alpha))
+  return (1 / (2 * alpha - 1)) * ((2 * alpha / (2 * alpha - 1) / c) ** (-2 * alpha))
+
 
 def theory_m_batched(v, d, alpha, xs,
-              eta = -6,
-              eta0 = 6.0,
-              etasteps=50,
-              batches = 100,
-              zbatch=1000):
-  """Generate the powerlaw m by Newton's method
-
+                     eta = -6,
+                     eta0 = 6.0,
+                     eta_steps = 50,
+                     j_batch = 100,
+                     x_batch = 1000):
+  """Split xs into batches then generate the powerlaw m by Newton's method on each batch.
 
   Parameters
   ----------
@@ -116,69 +117,90 @@ def theory_m_batched(v, d, alpha, xs,
       The vector of x-positions at which to estimate the spectrum.  Complex is also possible.
   eta : float
       Error tolerance
+  j_batch: int
+      Batch size for j, which ranges from 1 to v. This prevents memory usage from growing with v
+      inside the Newton method update.
+  x_batch: int
+      Batch size for x's. More x's creates a finer grid used to discretize the density when integrating
+      so batching x's is required to prevent memory usage from growing as we increase the accuracy.
 
   Returns
   -------
-  m_Lambda: vector
+  ms: vector
       m_Lambda evaluated at xs.
   """
-  #if zbatch > 0:
-  #    xsplit = jnp.split(xs,jnp.arange(1,len(xs)//zbatch,1)*zbatch)
-  #    ms = jnp.concatenate( [jax_gen_m_batched(v,d,alpha,x,eta,eta0,etasteps,batches,zbatch=0) for x in xsplit] )
-  #    return ms
-  v=jnp.int32(v)
-  d=jnp.complex64(d)
+
   xs=jnp.complex64(xs)
-  xsplit = jnp.split(xs,jnp.arange(1,len(xs)//zbatch,1)*zbatch)
+  xsplits = jnp.split(xs,jnp.arange(1, len(xs) // x_batch, 1) * x_batch)
+  ms = jnp.concatenate([theory_m_batched_xsplit(v, d, alpha, xsplit, eta, eta0, eta_steps, j_batch) for xsplit in xsplits])
+
+  return ms
 
 
-  #print("xs length = {}".format(len(xs)))
+def theory_m_batched_xsplit(v, d, alpha, xsplit, eta, eta0, eta_steps, j_batch):
+  """Generate the powerlaw m by Newton's method.
 
-  js=jnp.arange(1,v+1,1,dtype=jnp.complex64)**(-2.0*alpha)
-  jt=jnp.reshape(js,(batches,-1))
-  onesjtslice=jnp.ones_like(jt)[0]
+
+  Parameters
+  ----------
+  v,d,alpha : floats
+      parameters of the model
+  xsplit : vector
+      The vector of x-positions at which to estimate the spectrum.  Complex is also possible.
+  eta : float
+      Error tolerance
+  j_batch: int
+      Batch size for j, which ranges from 1 to v. This prevents memory usage from growing with v
+      inside the Newton method update.
+
+  Returns
+  -------
+  msplit: vector
+      m_Lambda evaluated at xsplit.
+  """
+  v = jnp.int32(v)
+  d = jnp.complex64(d)
+  js = jnp.arange(1, v+1, 1, dtype=jnp.complex64) ** (-2.0 * alpha)
+  jt = jnp.reshape(js, (j_batch, -1))
+  ones_jt_slice = jnp.ones_like(jt)[0]
 
   # One Newton's method update step for current estimate m on a single value of z
   def mup_single(m,z):
       m1 = m
-      F=m1
-      Fprime=jnp.ones_like(m1,dtype=jnp.complex64)
-      for j in range(batches):
-          denom = (jnp.outer(jt[j],m1) - jnp.outer(onesjtslice,z))
-          F += (1.0/d)*jnp.sum(jnp.outer(jt[j],m1)/denom,axis=0)
-          Fprime -= (1.0/d)*jnp.sum(jnp.outer(jt[j],z)/(denom**2),axis=0)
-      return (-F + 1.0)/Fprime + m1
-      #return 0.1*jnp.where(mask, m1, newm1)+0.9*m1
+      F = m1
+      Fprime = jnp.ones_like(m1, dtype=jnp.complex64)
+      for j in range(j_batch):
+          denom = (jnp.outer(jt[j], m1) - jnp.outer(ones_jt_slice, z))
+          F += (1.0 / d) * jnp.sum(jnp.outer(jt[j], m1) / denom, axis=0)
+          Fprime -= (1.0 / d) * jnp.sum(jnp.outer(jt[j], z) / (denom ** 2), axis=0)
+      return (-F + 1.0) / Fprime + m1
 
-#    mup_single = jax.jit(mup_single, static_argnums=(0,1))
+  def mup_scan_body(ms, z, x):
+      return mup_single(ms, z*1.0j+x), False
 
-  def mup_scanner(ms,z,x):
-      return mup_single(ms,z*1.0j+x), False
+  etas = jnp.logspace(eta0, eta, num=eta_steps)
+  msplit = jax.lax.scan(lambda m, z: mup_scan_body(m, z, xsplit), jnp.ones_like(xsplit, dtype=jnp.complex64), etas)[0]
+  return msplit
 
-  #mup_scanner = jax.jit(mup_scanner, static_argnums=(0,1))
-  #mup_scannerjit =  jax.jit(mup_scanner)
 
-  etas = jnp.logspace(eta0,eta,num = etasteps)
-  ms = jnp.concatenate([jax.lax.scan(lambda m,z: mup_scanner(m,z,x),jnp.ones_like(x, dtype = jnp.complex64),etas)[0] for x in xsplit])
-  #ms, _ = jax.lax.scan(mup_scanner,jnp.ones_like(xs),etas)
-
-  return ms
-
-def theory_f_measure(v,d, alpha, beta, xs,
-              err = -6.0, timeChecks = False, batches=100):
+def theory_f_measure(v, d, alpha, beta, xs, m_fn = theory_m_batched,
+                     err = -6.0, time_checks = False, j_batch=100):
   """Generate the trace resolvent
 
 
   Parameters
   ----------
-  v,d,alpha,beta : floats
+  v, d, alpha, beta : floats
       parameters of the model
   xs : floats
       X-values at which to return the trace-resolvent
   err : float
       Error tolerance, log scale
-  timeChecks: bool
+  m_fn: function
+      A function that will return ms on a set of zs
+  time_checks: bool
       Print times for each part
+  j_batch: batch size across v dimension
 
   Returns
   -------
@@ -187,47 +209,45 @@ def theory_f_measure(v,d, alpha, beta, xs,
   """
 
   eps = 10.0**(err)
-
   zs = xs + 1.0j*eps
 
-  if timeChecks:
+  if time_checks:
       print("The number of points on the spectral curve is {}".format(len(xs)))
 
-  eta = jnp.log10(eps*(d**(-2*alpha)))
+  eta = jnp.log10(eps * (d ** (-2 * alpha)))
   eta0 = 6
-  etasteps = jnp.int32(40 + 10*(2*alpha)*jnp.log(d))
+  eta_steps = jnp.int32(40 + 10 * (2 * alpha) * jnp.log(d))
 
-  start=time.time()
-  if timeChecks:
-      print("Running the Newton generator with {} steps".format(etasteps))
+  start = time.time()
+  if time_checks:
+      print("Running the Newton generator with {} steps".format(eta_steps))
 
-  ms = theory_m_batched(v,d,alpha,zs,eta,eta0,etasteps,batches)
+  ms = m_fn(v, d, alpha, zs, eta, eta0, eta_steps, j_batch)
 
   end = time.time()
-  if timeChecks:
-      print("Completed Newton in {} time".format(end-start) )
+  if time_checks:
+      print("Completed Newton in {} time".format(end - start))
   start = end
 
-  js=jnp.arange(1,v+1,1)**(-2.0*alpha)
-  jbs=jnp.arange(1,v+1,1)**(-2.0*(alpha+beta))
+  js = jnp.arange(1, v+1, 1) ** (-2.0 * alpha)
+  jbs = jnp.arange(1, v+1, 1) ** (-2.0 * (alpha + beta))
 
-  jt=jnp.reshape(js,(batches,-1))
-  jbt=jnp.expand_dims(jnp.reshape(jbs,(batches,-1)),-1)
-  onesjtslice=jnp.ones_like(jt)[0]
+  jt = jnp.reshape(js, (j_batch, -1))
+  jbt = jnp.expand_dims(jnp.reshape(jbs, (j_batch, -1)), -1)
+  ones_jt_slice = jnp.ones_like(jt)[0]
 
-  Fmeasure = jnp.zeros_like(ms)
+  F_measure = jnp.zeros_like(ms)
 
-  for j in range(batches):
-      Fmeasure += jnp.sum(jbt[j]/(jnp.outer(jt[j],ms) - jnp.outer(onesjtslice,zs + 1.0j*(10**eta))),axis=0)
+  for j in range(j_batch):
+      F_measure += jnp.sum(jbt[j] / (jnp.outer(jt[j], ms) - jnp.outer(ones_jt_slice, zs + 1.0j * (10 ** eta))), axis=0)
 
+  return jnp.imag(F_measure / zs) / jnp.pi
 
-
-  return jnp.imag(Fmeasure/zs) / jnp.pi
 
 def chunk_weights(xs, density, a, b):
     # Compute integrals
-      integrals = []
-      def theoretical_integral(lower, upper):
+    integrals = []
+    def theoretical_integral(lower, upper):
         # Normalize density to make it a probability measure
         dx = xs[1] - xs[0]
         #norm = jnp.sum(density) * dx
@@ -237,15 +257,14 @@ def chunk_weights(xs, density, a, b):
         idx = (xs >= lower) & (xs <= upper)
         integral = jnp.sum(density[idx]) * dx
         return float(integral)
-      i = 0
-      for lower, upper in zip(a,b):
+    i = 0
+    for lower, upper in zip(a,b):
         integrals.append(theoretical_integral(lower, upper))
-        #integrals.at[i].set(theoretical_integral(lower, upper))
         i = i+ 1
-      return integrals
+    return integrals
 
 
-def theory_rho_weights(v,d,alpha,beta,num_splits, a, b, xs_per_split = 10000):
+def theory_rho_weights(v, d, alpha, beta, num_splits, a, b, f_measure_fn = theory_f_measure, xs_per_split = 10000):
   """Generate the initial rho_j's deterministically.
   This performs many small contour integrals each surrounding the real eigenvalues
   where the vector a contains the values for the lower (left) edges of the
@@ -302,18 +321,10 @@ def theory_rho_weights(v,d,alpha,beta,num_splits, a, b, xs_per_split = 10000):
     batches = 1
 
     zs = xs.astype(jnp.complex64)
-    density = theory_f_measure(v, d, alpha, beta, zs, err=err, batches = batches)
+    density = f_measure_fn(v, d, alpha, beta, zs, err=err, j_batch=batches)
 
     rho_weights_split = chunk_weights(xs, density, a_split, b_split)
     rho_weights_split = jnp.array(rho_weights_split)
     rho_weights = jnp.concatenate([rho_weights, rho_weights_split], axis=0)
 
   return rho_weights
-# Compute density for all splits
-#density = jax.vmap(lambda z: jax_gen_trace_fmeasure(V, D, alpha, beta, z, err=-10, batches=1))(zs)
-
-# Compute rho_weights for all splits
-#rho_weights = jnp.array([weights(x, d, a_s, b_s) for x, d, a_s, b_s in zip(xs, density, a_splits, b_splits)])
-
-# Flatten the rho_weights
-#rho_weights = rho_weights.flatten()


### PR DESCRIPTION
- Split up the functions that generate F_measure and rho_init so they are easier to parallelize
- Clean up whitespaces / variable naming
- Add comments explaining why there is batching over two different dimensions

Testing:
- Copy / pasted these functions into a colab and tested the ODE runs using these functions to generate the inputs