### PR TITLE
Rename rho functions

### DIFF
--- a/power_law_rf/deterministic_equivalent.py
+++ b/power_law_rf/deterministic_equivalent.py
@@ -287,7 +287,7 @@ def chunk_weights(xs, density, a, b):
     return integrals
 
 
-def theory_rho_weights(v, d, alpha, beta, num_splits, a, b, f_measure_fn = theory_f_measure, xs_per_split = 10000):
+def deterministic_rho_weights(v, d, alpha, beta, num_splits, a, b, f_measure_fn = theory_f_measure, xs_per_split = 10000):
   """Generate the initial rho_j's deterministically.
   This performs many small contour integrals each surrounding the real eigenvalues
   where the vector a contains the values for the lower (left) edges of the


### PR DESCRIPTION
- Rename `theory_rho_weights` to `deterministic_rho_weights` because we now also have `theory_rho` that doesn't compute a deterministic equivalent.