### PR TITLE
Add new scripts for DANA experiments and LSTM training on the Billion…

### DIFF
--- a/dana-nonquadratic-tests/cifar5m-resnet/README.md
+++ b/dana-nonquadratic-tests/cifar5m-resnet/README.md
@@ -1,0 +1,12 @@
+This is an experiment for running DANA on ResNets.
+
+It assumes access to cifar5m:
+
+https://github.com/preetum/cifar5m?tab=readme-ov-file
+
+It assumes all *.npz files have been colocated in one folder.
+
+The ResNet implementation and experiment code are all in flax-cifar5m-resnet-sweep.
+
+No batchnorm is used, and all activations were replaced by normalized activation functions (softSign).
+

--- a/dana-nonquadratic-tests/cifar5m-resnet/flax-cifar5m-resnet-sweep.py
+++ b/dana-nonquadratic-tests/cifar5m-resnet/flax-cifar5m-resnet-sweep.py
@@ -1,0 +1,639 @@
+import tensorflow as tf
+
+tf.config.set_visible_devices([], 'GPU')
+tf.random.set_seed(0)  # Set the random seed for reproducibility.
+
+import jax
+from jax.tree_util import tree_leaves, tree_map
+import jax.numpy as jnp
+from flax import nnx
+import optax
+import numpy as np
+from functools import partial
+import glob
+from tqdm import tqdm
+
+#from flaxresnets import ResNet18
+from typing import Sequence
+from typing import Dict, Any
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import scipy.stats as stats
+
+import pickle
+
+
+#From LosVolterros
+import sys
+sys.path.append('../../')
+import optimizers
+
+
+
+
+# Configuration
+BATCH_SIZE = 128
+TRAIN_STEPS = 5000*20
+POPULATION_TRACE = 4.0
+#NUM_FILTERS = 32 
+CHUNK_SIZE = 10000  # Number of examples to load at once
+BASE_PATH = '/home/elliotpaquette/Documents/SGD/cifar5m'
+
+TRAIN_FILES = sorted(glob.glob(f"{BASE_PATH}/cifar5m_part[0-3]*.npz"))
+VAL_FILE = f"{BASE_PATH}/cifar5m_part4.npz"
+
+
+
+
+def count_parameters(model: nnx.Module):
+    """
+    Computes the number of parameters in a Flax NNX model.
+    
+    Args:
+        model: An nnx.Module instance
+        
+    Returns:
+        An integer representing the total number of parameters in the model.
+    """
+    # Get the state dict from the model
+    state = nnx.state(model)
+    return np.sum([np.prod(x.shape) for x in tree_leaves(state)])
+
+
+
+class ResNetSoftSignBlock(nnx.Module):
+    """
+    A ResNet block implementation that uses SoftSign activation function instead of the traditional ReLU.
+    
+    This block consists of two convolutional layers with SoftSign activations and implements a residual
+    connection. If the input and output dimensions differ or if strides are not (1,1), a projection
+    convolution is applied to the residual path to match dimensions.
+    
+    Attributes:
+        strides: Tuple of integers specifying the stride length for the first convolution
+        conv1: First convolutional layer
+        conv2: Second convolutional layer
+        conv_proj: Optional projection convolution for the residual path
+    """
+    def __init__(self, in_features: int, out_features: int, strides: tuple[int, int], rngs: nnx.Rngs):
+        super().__init__()
+        self.strides = strides
+        
+        # Define the layers with their initializers
+        self.conv1 = nnx.Conv(
+            in_features=in_features,
+            out_features=out_features,
+            kernel_size=(3, 3),
+            strides=self.strides,
+            use_bias=True,
+            kernel_init=nnx.initializers.lecun_normal(),
+            rngs=rngs
+        )
+        self.conv2 = nnx.Conv(
+            in_features=out_features,
+            out_features=out_features,
+            kernel_size=(3, 3),
+            use_bias=True,
+            kernel_init=nnx.initializers.lecun_normal(),
+            rngs=rngs
+        )
+        
+        # Projection layers for residual (only if shapes differ)
+        if in_features != out_features or strides != (1, 1):
+            self.conv_proj = nnx.Conv(
+                in_features=in_features,
+                out_features=out_features,
+                kernel_size=(1, 1),
+                strides=self.strides,
+                use_bias=True,
+                kernel_init=nnx.initializers.lecun_normal(),
+                rngs=rngs
+            )
+        
+    def __call__(self, x, train: bool = True):
+        residual = x
+        
+        # First conv block
+        x = self.conv1(x)
+        x = nnx.soft_sign(x)
+        
+        # Second conv block
+        x = self.conv2(x)
+        x = nnx.soft_sign(x)
+        
+        # Adjust residual if needed
+        if hasattr(self, 'conv_proj'):
+            residual = self.conv_proj(residual)
+            residual = nnx.soft_sign(residual)
+        
+        return nnx.relu(residual + x)
+
+class ResNetSoftSign(nnx.Module):
+    """
+    A ResNet model implementation that uses SoftSign activation function instead of the traditional ReLU (AND NO BATCH NORM).
+    
+    This model consists of an initial convolutional layer followed by a series of ResNet blocks with SoftSign activations.
+    The final layer is a dense layer for classification.
+    """
+    def __init__(self, stage_sizes: Sequence[int], num_classes: int, num_filters: int, rngs: nnx.Rngs):
+        super().__init__()
+        
+        # Initial conv block
+        self.conv_init = nnx.Conv(
+            in_features=3,
+            out_features=num_filters,
+            kernel_size=(7, 7),
+            strides=(2, 2),
+            padding=[(3, 3), (3, 3)],
+            use_bias=True,
+            kernel_init=nnx.initializers.lecun_normal(),
+            rngs=rngs
+        )        
+        # Residual blocks
+        self.blocks = []
+        in_features = num_filters
+        for i, block_size in enumerate(stage_sizes):
+            out_features = num_filters * 2**i
+            for j in range(block_size):
+                strides = (2, 2) if i > 0 and j == 0 else (1, 1)
+                block = ResNetSoftSignBlock(
+                    in_features=in_features,
+                    out_features=out_features,
+                    strides=strides,
+                    rngs=rngs
+                )
+                self.blocks.append(block)
+                in_features = out_features
+        
+        # Final dense layer
+        final_features = num_filters * 2**(len(stage_sizes)-1)
+        self.linear = nnx.Linear(
+            in_features=final_features,
+            out_features=num_classes,
+            kernel_init=nnx.initializers.lecun_normal(),
+            rngs=rngs
+        )
+    
+    def __call__(self, x, train: bool = True):
+        # Initial conv block
+        x = self.conv_init(x)
+        x = nnx.soft_sign(x)
+        x = nnx.max_pool(x, (3, 3), strides=(2, 2), padding='SAME')
+        
+        # Residual blocks
+        for block in self.blocks:
+            x = block(x, train)
+        
+        # Final layers
+        x = jnp.mean(x, axis=(1, 2))
+        x = self.linear(x)
+        return x
+
+class ChunkedNpzDataset:
+
+    """
+    A dataset class for loading and processing CIFAR-5M data in chunks.
+    
+    This class provides a way to load CIFAR-5M data from a .npz file in memory-mapped mode,
+    and apply optional data augmentation to the images. The data is then batched and yielded in chunks.
+    """
+    def __init__(self, file_path, batch_size, chunk_size=10000, apply_augmentation=True):
+        self.npz = np.load(file_path, mmap_mode='r')  # Memory-mapped mode
+        self.images = self.npz['X']
+        self.labels = self.npz['Y']
+        self.num_examples = len(self.labels)
+        self.batch_size = batch_size
+        self.chunk_size = chunk_size
+        self.apply_augmentation = apply_augmentation
+        
+    def __iter__(self):
+        # Calculate number of chunks
+        num_chunks = (self.num_examples + self.chunk_size - 1) // self.chunk_size
+        
+        for chunk_idx in range(num_chunks):
+            # Get sequential indices for this chunk
+            start_idx = chunk_idx * self.chunk_size
+            end_idx = min(start_idx + self.chunk_size, self.num_examples)
+            
+            # Load chunk into memory and normalize
+            chunk_images = self.images[start_idx:end_idx].astype(np.float32) / 255.0
+            chunk_labels = self.labels[start_idx:end_idx]
+            
+            # Create dataset for this chunk
+            dataset = tf.data.Dataset.from_tensor_slices({
+                'image': chunk_images,
+                'label': chunk_labels
+            })
+            
+            # Apply data augmentation if enabled
+            if self.apply_augmentation:
+                dataset = dataset.map(
+                    self._augment_data,
+                    num_parallel_calls=tf.data.AUTOTUNE
+                )
+            
+            dataset = dataset.batch(self.batch_size)
+            
+            # Yield batches from this chunk
+            for batch in dataset:
+                yield {k: v.numpy() for k, v in batch.items()}
+    
+    def _augment_data(self, data):
+        """Apply standard data augmentation to images."""
+        image = data['image']
+        label = data['label']
+        
+        # Random horizontal flip
+        image = tf.image.random_flip_left_right(image)
+        
+        # Random crop and resize back to original size
+        image = tf.image.resize_with_crop_or_pad(image, 40, 40)  # Pad to larger size
+        image = tf.image.random_crop(image, [32, 32, 3])  # Random crop back to original
+        
+        # Random 90-degree rotation
+        k = tf.random.uniform([], 0, 4, dtype=tf.int32)  # Random integer from [0, 1, 2, 3]
+        image = tf.image.rot90(image, k)  # Rotate by k*90 degrees
+        
+        # Random brightness, contrast, and saturation
+        image = tf.image.random_brightness(image, max_delta=0.2)
+        image = tf.image.random_contrast(image, lower=0.8, upper=1.2)
+        image = tf.image.random_saturation(image, lower=0.8, upper=1.2)
+        
+        # Ensure values stay in valid range [0,1]
+        image = tf.clip_by_value(image, 0.0, 1.0)
+        
+        return {'image': image, 'label': label}
+        
+    def __len__(self):
+        return self.num_examples // self.batch_size
+
+def run_resnet_loop(model, optax_optimizer, val_dataset, train_steps, losscomparison=None, store_sigmoid_sum=True):
+    """
+    Main training loop for a ResNet model using the specified optimizer.
+    
+    This function orchestrates the training process, including loss computation, gradient calculation,
+    parameter updates, and validation. It also handles optional loss comparison and sigmoid sum tracking.
+    """
+    metrics = nnx.MultiMetric(
+    accuracy=nnx.metrics.Accuracy(),
+    loss=nnx.metrics.Average('loss'),
+    grad_norm=nnx.metrics.Average('grad_norm'),
+    sigmoid_sum=nnx.metrics.Average('sigmoid_sum'),
+    )
+
+    metrics_history = {
+        'train_loss': [],
+        'train_accuracy': [],
+        'train_grad_norm': [],  
+        'train_sigmoid_sum': [],
+        'val_loss': [],
+        'val_accuracy': [],
+        'val_grad_norm': [],   
+        'val_sigmoid_sum': [],
+    }
+
+    optimizer = nnx.Optimizer(model, optax_optimizer)
+
+
+    def loss_fn(model: ResNetSoftSign, batch):
+        logits = model(batch['image'])
+        loss = optax.softmax_cross_entropy_with_integer_labels(
+            logits=logits, labels=batch['label']
+        ).mean()
+        return loss, logits
+
+    @nnx.jit
+    def train_step(model: ResNetSoftSign, optimizer: nnx.Optimizer, metrics: nnx.MultiMetric, batch):
+        """Train for a single step."""
+        grad_fn = nnx.value_and_grad(loss_fn, has_aux=True)
+        (loss, logits), grads = grad_fn(model, batch)
+        
+        # Compute gradient norm
+        grad_norm = jnp.sqrt(sum(jnp.sum(jnp.square(g)) for g in tree_leaves(grads)))
+
+        if store_sigmoid_sum:
+            sigmoid_sum = optimizer.opt_state.sigmoid_sum
+        else:
+            sigmoid_sum = 0.0
+        metrics.update(loss=loss, logits=logits, labels=batch['label'], grad_norm=grad_norm, sigmoid_sum=sigmoid_sum)  # In-place updates.
+        optimizer.update(grads)  # In-place updates.
+
+    @nnx.jit
+    def eval_step(model: ResNetSoftSign, metrics: nnx.MultiMetric, batch):
+        grad_fn = nnx.value_and_grad(loss_fn, has_aux=True)
+        (loss, logits), grads = grad_fn(model, batch)
+        
+        # Compute gradient norm
+        grad_norm = jnp.sqrt(sum(jnp.sum(jnp.square(g)) for g in tree_leaves(grads)))
+        
+        metrics.update(loss=loss, logits=logits, labels=batch['label'], grad_norm=grad_norm, sigmoid_sum=0.0)  # In-place updates.
+
+    # Training loop
+    step = 0
+    loss_times = jnp.unique(jnp.concatenate(
+        [jnp.array([0]),
+        jnp.int32(
+            1.1**jnp.arange(1,jnp.ceil(jnp.log(train_steps)/jnp.log(1.1)))
+        ),
+        jnp.array([train_steps])]
+        ))
+
+    losscomp = None
+    if losscomparison is not None:
+        losscomp = iter(losscomparison['train_loss'])
+    
+    #with tqdm(total=train_steps, initial=step, desc='Training') as pbar:
+    while step < train_steps:
+    # Cycle through training files
+        for train_file in TRAIN_FILES:
+            train_dataset = ChunkedNpzDataset(train_file, BATCH_SIZE, CHUNK_SIZE)
+            
+            for batch in train_dataset:
+                if step >= train_steps:
+                    break
+                    
+                train_step(model, optimizer, metrics, batch)
+                
+                #f step > 0 and (step in loss_times):
+                if step in loss_times:
+                    # Log training metrics
+                    for metric, value in metrics.compute().items():
+                        metrics_history[f'train_{metric}'].append(value)
+                    metrics.reset()
+                    
+                    for val_batch in val_dataset:
+                        eval_step(model, metrics, val_batch)
+                    
+                    for metric, value in metrics.compute().items():
+                        metrics_history[f'val_{metric}'].append(value)
+                    metrics.reset()
+                    
+                    if losscomparison is not None:
+                        loss_diff = metrics_history['train_loss'][-1] / next(losscomp)
+                        color = "\033[31m" if loss_diff >= 1.0 else "\033[32m"  # Red if sgd-favoured, green else
+                        print(
+                            f"[train] step: {step}, "
+                            f"loss-ratio: {color}{loss_diff}\033[0m, "
+                            f"sigmoid_sum: {metrics_history['train_sigmoid_sum'][-1]}, "
+                        )
+                        # print(
+                        #     f"[val] step: {step}, "
+                        #     f"loss: {metrics_history['val_loss'][-1]}, "
+                        #     f"accuracy: {metrics_history['val_accuracy'][-1] * 100}%, "
+                        #     f"grad_norm: {metrics_history['val_grad_norm'][-1]:.6f}"    # Add this line
+                        # )
+                    else:
+                        print(
+                            f"[train] step: {step}, "
+                            f"loss: {metrics_history['train_loss'][-1]}, "
+                            f"accuracy: {metrics_history['train_accuracy'][-1] * 100}%, "
+                            f"grad_norm: {metrics_history['train_grad_norm'][-1]:.6f}"  # Add this line
+                        )
+                        print(
+                            f"[val] step: {step}, "
+                            f"loss: {metrics_history['val_loss'][-1]}, "
+                            f"accuracy: {metrics_history['val_accuracy'][-1] * 100}%, "
+                            f"grad_norm: {metrics_history['val_grad_norm'][-1]:.6f}"    # Add this line
+                        )
+                    
+                step += 1
+                if step >= train_steps:
+                    break
+                del batch
+            del train_dataset
+    return loss_times, metrics_history, count_parameters(model)
+
+# # Compute validation metrics on a chunk of validation data
+# val_dataset = ChunkedNpzDataset(VAL_FILE, BATCH_SIZE, CHUNK_SIZE, apply_augmentation=True)
+# subval_dataset = list(val_dataset)[:10]  # Only use first 10 batches for validation
+# del val_dataset
+
+# population_trace = 4.0 #this number was based on earlier simulations but is essentially arbitrary
+# est_alpha = 0.66
+# est_beta = 1.0
+# g1 = optimizers.powerlaw_schedule(1.0, 0.0, 0.0, 1)
+# g2 = optimizers.powerlaw_schedule(0.4/population_trace, 0.0, 0.0, 1)
+# delta = 8
+# Delta = optimizers.powerlaw_schedule(1.0, 0.0, -1.0, delta)
+
+# g3_iv = 2.0/population_trace
+# g3_sv = 0.0
+# g3_p = -2.0
+# g3_ts = 1.0
+# g3 = optimizers.powerlaw_schedule(g3_iv, g3_sv, g3_p, g3_ts)
+# g4 = optimizers.powerlaw_schedule(jnp.sqrt(1.0/delta), 0.0, 0.5, 1.0)
+# thresholder = lambda d: jnp.sqrt(1.0) #UNUSED
+
+# dananormalizedopt = optimizers.dana_optimizer_normalized_mk3(g1=g1,g2=g2,g3=g3,g4=g4,Delta=Delta)
+
+
+# # Run SGD or load SGD results
+# sgd_metrics_filename = f"sgd_metrics_history_steps_{TRAIN_STEPS}_filters_{NUM_FILTERS}.pkl"
+# #The below generates SGD results
+# try:
+#     sgd_metrics_history = pickle.load(open(sgd_metrics_filename, "rb"))
+# except (FileNotFoundError, IOError):
+#     # If the file doesn't exist, the SGD code below will run and create it
+#     sgd_metrics_history = None
+#     # Reset model with same initialization
+#     rngs = nnx.Rngs(0)  # Use same seed for fair comparison
+#     model = ResNetSoftSign(stage_sizes=[2, 2, 2, 2], num_classes=10, num_filters=NUM_FILTERS, rngs=rngs)
+
+#     learning_rate = 0.1
+#     momentum = 0.0
+
+#     # Create learning rate schedule that decays over TRAIN_STEPS
+#     schedule = optax.linear_schedule(
+#         init_value=learning_rate,
+#         end_value=0.0,
+#         transition_steps=TRAIN_STEPS
+#     )
+#     sgd = optax.sgd(schedule, momentum)
+
+
+#     sgd_loss_times, sgd_metrics_history, _ = run_resnet_loop(model, sgd, subval_dataset, TRAIN_STEPS,store_sigmoid_sum=False)
+#     # Save the metrics history dictionary to a file
+#     with open(sgd_metrics_filename, 'wb') as f:
+#         pickle.dump(sgd_metrics_history, f)
+#     print(f"SGD metrics history saved to {sgd_metrics_filename}")
+
+# # RUN DANA
+# # Create model with rngs
+# rngs = nnx.Rngs(0)  # Initialize with a seed
+# model = ResNetSoftSign(stage_sizes=[2, 2, 2, 2], num_classes=10, num_filters=NUM_FILTERS, rngs=rngs)
+# #model = ResNetSoftSign(stage_sizes=[3, 4, 6, 3], num_classes=10, num_filters=64, rngs=rngs)
+
+# # Run with DANA optimizer
+# dana_loss_times, dana_metrics_history, dimension = run_resnet_loop(model, dananormalizedopt, subval_dataset, TRAIN_STEPS,losscomparison=sgd_metrics_history)
+
+# # Save DANA results
+# # Note that total parameters = 44668662*(NUM_FILTERS**2)/(128**2)
+# dana_mk4_metrics_filename = f"dana_normalized_mk3_metrics_history_steps_{TRAIN_STEPS}_filters_{NUM_FILTERS}_g3_iv={g3_iv}_sv={g3_sv}_p={g3_p}_ts={g3_ts}_delta={delta}.pkl"
+# with open(dana_mk4_metrics_filename, 'wb') as f:
+#     pickle.dump(dana_metrics_history, f)
+
+# print(f"DANA metrics history saved to {dana_mk4_metrics_filename}")
+
+# # Plot loss and accuracy in subplots
+# fig, ax1 = plt.subplots(1, 1, figsize=(8, 5))
+# ax1.set_title('Loss')
+# # Create a second y-axis for sigmoid-sum
+# ax1_right = ax1.twinx()
+# ax1_right.set_yscale('log')
+# ax1_right.set_ylabel('Sigmoid Sum', color='grey')
+
+# # Plot DANA results
+# for dataset in ('train', 'val'):
+#     flopscalar = BATCH_SIZE * dimension
+#     x_values = flopscalar * np.float32(dana_loss_times[:-1])
+#     ax1.loglog(x_values, dana_metrics_history[f'{dataset}_loss'], label=f'DANA {dataset}_loss')
+#     if dataset == 'train':
+#         ax1_right.loglog(x_values, dana_metrics_history['train_sigmoid_sum'], color='grey', linestyle='--', label='Sigmoid Sum')
+#         ax1_right.tick_params(axis='y', labelcolor='grey')
+
+# # Plot SGD results
+# for dataset in ('train', 'val'):
+#     flopscalar = BATCH_SIZE * dimension
+#     length = min(len(sgd_metrics_history['train_loss']),len(dana_loss_times)-1)
+#     x_values = flopscalar * np.float32(dana_loss_times[:length])
+#     sgdtrain = sgd_metrics_history[f'{dataset}_loss'][:length]
+#     sgdacc = 1.0-np.array(sgd_metrics_history[f'{dataset}_accuracy'][:length])
+#     ax1.loglog(x_values, sgdtrain, label=f'SGD {dataset}_loss')
+
+# # Add horizontal and vertical grid lines
+# ax1.grid(True, which='both', axis='both', linestyle='--', alpha=0.7)
+
+# # Set more y-axis ticks (equally spaced in log-space)
+# import matplotlib.ticker as ticker
+# ax1.yaxis.set_major_locator(ticker.LinearLocator(numticks=15))
+
+# ax1.yaxis.set_major_formatter(ticker.FormatStrFormatter('%.3g'))
+# ax1.yaxis.set_minor_locator(ticker.NullLocator())
+
+# ax1.set_xlabel('FLOPs')
+# ax1.legend(loc='upper left')
+# ax1_right.legend(loc='lower left')
+
+# fig.suptitle("DANA Normalized MK3, filters={}".format(NUM_FILTERS))
+# plt.savefig("cifar5m_resnet18_filters_{}_dana_normalized_mk3_delta={}_g3_iv={}_sv={}_p={}_ts={}_D={}_ITER={}.pdf".format(NUM_FILTERS, delta, g3_iv, g3_sv, g3_p, g3_ts, dimension, TRAIN_STEPS*BATCH_SIZE))
+
+def run_experiment(subval_dataset, NUM_FILTERS, g3_p, g3_iv, g3_sv, g3_ts, delta=8):
+    """
+    Run a single experiment with given parameters.
+    """
+    # Run SGD or load SGD results
+    sgd_metrics_filename = f"Results/sgd/sgd_metrics_history_steps_{TRAIN_STEPS}_filters_{NUM_FILTERS}.pkl"
+    
+    try:
+        sgd_metrics_history = pickle.load(open(sgd_metrics_filename, "rb"))
+    except (FileNotFoundError, IOError):
+        # If the file doesn't exist, run SGD and create it
+        sgd_metrics_history = None
+        # Reset model with same initialization
+        rngs = nnx.Rngs(0)  # Use same seed for fair comparison
+        model = ResNetSoftSign(stage_sizes=[2, 2, 2, 2], num_classes=10, num_filters=NUM_FILTERS, rngs=rngs)
+
+        learning_rate = 0.1
+        momentum = 0.0
+
+        schedule = optax.linear_schedule(
+            init_value=learning_rate,
+            end_value=0.0,
+            transition_steps=TRAIN_STEPS
+        )
+        sgd = optax.sgd(schedule, momentum)
+
+        sgd_loss_times, sgd_metrics_history, _ = run_resnet_loop(model, sgd, subval_dataset, TRAIN_STEPS, store_sigmoid_sum=False)
+        with open(sgd_metrics_filename, 'wb') as f:
+            pickle.dump(sgd_metrics_history, f)
+        print(f"SGD metrics history saved to {sgd_metrics_filename}")
+
+    # Configure DANA optimizer
+    g1 = optimizers.powerlaw_schedule(1.0, 0.0, 0.0, 1)
+    g2 = optimizers.powerlaw_schedule(0.4/POPULATION_TRACE, 0.0, 0.0, 1)
+    Delta = optimizers.powerlaw_schedule(1.0, 0.0, -1.0, delta)
+    g3 = optimizers.powerlaw_schedule(g3_iv, g3_sv, g3_p, g3_ts)
+    
+    # Run DANA Classic
+    dana_classic = optimizers.dana_optimizer(g1=g1, g2=g2, g3=g3, Delta=Delta)
+    rngs = nnx.Rngs(0)
+    model = ResNetSoftSign(stage_sizes=[2, 2, 2, 2], num_classes=10, num_filters=NUM_FILTERS, rngs=rngs)
+    dana_loss_times, dana_metrics_history, dimension = run_resnet_loop(
+        model, dana_classic, subval_dataset, TRAIN_STEPS, losscomparison=sgd_metrics_history
+    )
+
+    # Save DANA Classic results
+    dana_classic_metrics_filename = f"Results/dana_classic/dana_classic_metrics_history_steps_{TRAIN_STEPS}_filters_{NUM_FILTERS}_g3_iv={g3_iv}_sv={g3_sv}_p={g3_p}_ts={g3_ts}_delta={delta}.pkl"
+    with open(dana_classic_metrics_filename, 'wb') as f:
+        pickle.dump(dana_metrics_history, f)
+    print(f"DANA Classic metrics history saved to {dana_classic_metrics_filename}")
+
+    # Create and save DANA Classic plot
+    fig, ax1 = plt.subplots(1, 1, figsize=(8, 5))
+    ax1.set_title('Loss')
+    ax1_right = ax1.twinx()
+    ax1_right.set_yscale('log')
+    ax1_right.set_ylabel('Sigmoid Sum', color='grey')
+
+    # Plot DANA results
+    for dataset in ('train', 'val'):
+        flopscalar = BATCH_SIZE * dimension
+        x_values = flopscalar * np.float32(dana_loss_times[:-1])
+        ax1.loglog(x_values, dana_metrics_history[f'{dataset}_loss'], label=f'DANA {dataset}_loss')
+        if dataset == 'train':
+            ax1_right.loglog(x_values, dana_metrics_history['train_sigmoid_sum'], color='grey', linestyle='--', label='Sigmoid Sum')
+            ax1_right.tick_params(axis='y', labelcolor='grey')
+
+    # Plot SGD results
+    for dataset in ('train', 'val'):
+        flopscalar = BATCH_SIZE * dimension
+        length = min(len(sgd_metrics_history['train_loss']), len(dana_loss_times)-1)
+        x_values = flopscalar * np.float32(dana_loss_times[:length])
+        sgdtrain = sgd_metrics_history[f'{dataset}_loss'][:length]
+        sgdacc = 1.0-np.array(sgd_metrics_history[f'{dataset}_accuracy'][:length])
+        ax1.loglog(x_values, sgdtrain, label=f'SGD {dataset}_loss')
+
+    ax1.grid(True, which='both', axis='both', linestyle='--', alpha=0.7)
+    ax1.yaxis.set_major_locator(ticker.LinearLocator(numticks=15))
+    ax1.yaxis.set_major_formatter(ticker.FormatStrFormatter('%.3g'))
+    ax1.yaxis.set_minor_locator(ticker.NullLocator())
+    ax1.set_xlabel('FLOPs')
+    ax1.legend(loc='upper left')
+    ax1_right.legend(loc='lower left')
+
+    fig.suptitle(f"DANA Classic, filters={NUM_FILTERS}")
+    plt.savefig(f"Results/dana_classic/cifar5m_resnet18_filters_{NUM_FILTERS}_dana_classic_delta={delta}_g3_iv={g3_iv}_sv={g3_sv}_p={g3_p}_ts={g3_ts}_D={dimension}_ITER={TRAIN_STEPS*BATCH_SIZE}.pdf")
+    plt.close()
+
+def main():
+    """
+    Run experiments over a grid of parameters.
+    """
+    # Define parameter grids
+    filter_values = list(range(32, 385, 32))  # 32, 64, 96, ..., 384
+    g3_iv_values = [0.00125/2.0, 0.00125/4.0, 0.00125/8.0, 0.00125/16.0, 0.00125/32.0, 0.00125/64.0, 0.00125/128.0, 0.00125/256.0, 0.00125/512.0, 0.00125/1024.0]
+    g3_ts_values = [1.0]
+
+    total_experiments = len(filter_values) * len(g3_iv_values)
+    completed = 0
+
+    val_dataset = ChunkedNpzDataset(VAL_FILE, BATCH_SIZE, CHUNK_SIZE, apply_augmentation=True)
+    subval_dataset = list(val_dataset)[:10]  # Only use first 10 batches for validation
+    del val_dataset
+
+    for num_filters in filter_values:
+        for g3_iv in g3_iv_values:
+            for g3_ts in g3_ts_values:
+                completed += 1
+                print(f"\nRunning experiment {completed}/{total_experiments}")
+                print(f"Parameters: NUM_FILTERS={num_filters}, g3_iv={g3_iv}, g3_ts={g3_ts}")
+                
+                try:
+                    run_experiment(subval_dataset, num_filters, g3_p=0.0, g3_iv=g3_iv, g3_ts=g3_ts, g3_sv=0.0)
+                except Exception as e:
+                    print(f"Error in experiment with NUM_FILTERS={num_filters}, g3_iv={g3_iv}")
+                    print(f"Error message: {str(e)}")
+                    continue
+
+if __name__ == "__main__":
+    main()

--- a/dana-nonquadratic-tests/cifar5m-resnet/plot_crossing_points_vs_iv.py
+++ b/dana-nonquadratic-tests/cifar5m-resnet/plot_crossing_points_vs_iv.py
@@ -1,0 +1,184 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import pickle
+import glob
+import os
+import scipy.stats as stats
+
+# Constants
+BATCH_SIZE = 128
+STEPS = 50000
+
+def count_parameters(num_filters):
+    """Calculate the number of parameters in the ResNet model for given number of filters"""
+    # Using the formula from the original code
+    return 44668662 * (num_filters**2) / (128**2)
+
+def generate_loss_times(train_steps):
+    """Generate the same time sequence as used in training"""
+    return np.unique(np.concatenate([
+        np.array([0]),
+        np.int32(1.1**np.arange(1, np.ceil(np.log(train_steps)/np.log(1.1)))),
+        np.array([train_steps])
+    ]))
+
+def extract_filters(filename):
+    """Extract the number of filters from a filename"""
+    # Find the part that starts with 'filters_' and ends with '_g3' or '.pkl'
+    start = filename.find('filters_') + len('filters_')
+    if '_g3' in filename:
+        end = filename.find('_g3')
+    else:
+        end = filename.find('.pkl')
+    return int(filename[start:end])
+
+def extract_iv(filename):
+    """Extract the initialization value (iv) from a filename"""
+    start = filename.find('iv=') + len('iv=')
+    end = filename.find('_sv=')
+    if start == -1 or end == -1:
+        print(f"Warning: Could not extract iv from filename: {filename}")
+        return None
+    try:
+        return float(filename[start:end])
+    except ValueError:
+        print(f"Warning: Could not convert iv to float in filename: {filename}")
+        return None
+
+def find_crossing_points(curve1_flops, curve1_losses, curve2_flops, curve2_losses):
+    """Find the last crossing point between two curves"""
+    # Interpolate curve2 onto curve1's flops points
+    curve2_losses_interp = np.interp(curve1_flops, curve2_flops, curve2_losses)
+    
+    # Find where curve1 crosses below curve2
+    crossings = np.where(curve1_losses < curve2_losses_interp)[0]
+    
+    if len(crossings) == 0:
+        return None, None
+    
+    # Get the last crossing point
+    last_crossing = crossings[-1]
+    return curve1_flops[last_crossing], curve1_losses[last_crossing]
+
+def plot_crossing_points_vs_iv(dana_files):
+    """Plot crossing points' step counts vs initialization values"""
+    plt.figure(figsize=(10, 6))
+    
+    # Process DANA files - group by filter size
+    filter_groups = {}
+    for pickle_file in dana_files:
+        num_filters = extract_filters(pickle_file)
+        if num_filters == 32:  # Skip outlier
+            continue
+            
+        if num_filters not in filter_groups:
+            filter_groups[num_filters] = []
+        filter_groups[num_filters].append(pickle_file)
+    
+    print(f"Found {len(filter_groups)} filter groups")
+    for num_filters, files in filter_groups.items():
+        print(f"Filter size {num_filters} has {len(files)} files")
+        for f in files:
+            iv = extract_iv(f)
+            print(f"  File: {f}, iv: {iv}")
+    
+    # Create color mapping for different filter sizes
+    colors = plt.cm.plasma(np.linspace(0, 0.8, len(filter_groups)))
+    
+    # Store all points for each filter size
+    all_points = {}
+    
+    # Collect all points for global fit
+    all_iv_values = []
+    all_step_counts = []
+    
+    for idx, (num_filters, group_files) in enumerate(filter_groups.items()):
+        # Sort files by iv value (descending)
+        group_files.sort(key=extract_iv, reverse=True)
+        
+        # Store points for this filter size
+        iv_values = []
+        step_counts = []
+        
+        # Find crossing points between consecutive curves
+        for i in range(len(group_files) - 1):
+            file1 = group_files[i]
+            file2 = group_files[i + 1]
+            
+            with open(file1, 'rb') as f:
+                data1 = pickle.load(f)
+            with open(file2, 'rb') as f:
+                data2 = pickle.load(f)
+            
+            losses1 = data1['train_loss']
+            losses2 = data2['train_loss']
+            times1 = generate_loss_times(STEPS)[:len(losses1)]
+            times2 = generate_loss_times(STEPS)[:len(losses2)]
+            flops1 = times1 * count_parameters(num_filters) * BATCH_SIZE
+            flops2 = times2 * count_parameters(num_filters) * BATCH_SIZE
+            
+            # Find the last crossing point
+            crossing_flops, crossing_losses = find_crossing_points(flops1, losses1, flops2, losses2)
+            if crossing_flops is not None:
+                # Convert flops back to steps
+                crossing_steps = crossing_flops / (count_parameters(num_filters) * BATCH_SIZE)
+                # Store the lower iv value (from file2)
+                lower_iv = extract_iv(file2)
+                
+                if lower_iv is not None:
+                    iv_values.append(lower_iv)
+                    step_counts.append(crossing_steps)
+                    all_iv_values.append(lower_iv)
+                    all_step_counts.append(crossing_steps)
+                    print(f"Found crossing point for filters={num_filters}: iv={lower_iv}, steps={crossing_steps}")
+        
+        # Store points for this filter size
+        all_points[num_filters] = (iv_values, step_counts)
+        
+        # Plot points for this filter size
+        if iv_values:
+            plt.loglog(step_counts, iv_values, 'o-', color=colors[idx], 
+                      label=f'Filters={num_filters}')
+            
+            # Fit line through points
+            slope, intercept, r_value, p_value, std_err = stats.linregress(
+                np.log10(step_counts), 
+                np.log10(iv_values)
+            )
+            x_fit = np.array([min(step_counts), max(step_counts)])
+            y_fit = 10**(slope * np.log10(x_fit) + intercept)
+            plt.loglog(x_fit, y_fit, '--', color=colors[idx], 
+                      label=f'Fit (slope={slope:.3f})')
+    
+    # Add global fit using all points
+    if all_iv_values and all_step_counts:
+        global_slope, global_intercept, global_r_value, global_p_value, global_std_err = stats.linregress(
+            np.log10(all_step_counts),
+            np.log10(all_iv_values)
+        )
+        x_global = np.array([min(all_step_counts), max(all_step_counts)])
+        y_global = 10**(global_slope * np.log10(x_global) + global_intercept)
+        plt.loglog(x_global, y_global, 'k-', linewidth=2,
+                  label=f'Global Fit (slope={global_slope:.3f}, intercept={global_intercept:.3f})')
+    
+    plt.ylabel('Initialization Value (iv)')
+    plt.xlabel('Steps at Crossing Point')
+    plt.title('Initialization Value vs Steps at Crossing Point')
+    plt.grid(True)
+    plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    plt.tight_layout()
+    plt.savefig('crossing_points_vs_iv.pdf', bbox_inches='tight')
+    plt.close()
+    
+    return all_points
+
+# Find and sort all files
+dana_files = glob.glob("Results/dana_classic/dana_classic_metrics_history_steps_50000_filters_*_g3_iv=*_sv=0.0_p=0.0_ts=1.0_delta=8.pkl")
+dana_files.sort(key=extract_filters)
+
+print(f"Found {len(dana_files)} DANA files")
+for f in dana_files:
+    print(f"File: {f}")
+
+# Generate plot
+all_points = plot_crossing_points_vs_iv(dana_files) 

--- a/dana-nonquadratic-tests/cifar5m-resnet/plot_dana_losses.py
+++ b/dana-nonquadratic-tests/cifar5m-resnet/plot_dana_losses.py
@@ -1,0 +1,94 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import pickle
+import glob
+import os
+import scipy.stats as stats
+
+# Constants
+BATCH_SIZE = 128
+STEPS = 50000
+
+def count_parameters(num_filters):
+    """Calculate the number of parameters in the ResNet model for given number of filters"""
+    # Using the formula from the original code
+    return 44668662 * (num_filters**2) / (128**2)
+
+def generate_loss_times(train_steps):
+    """Generate the same time sequence as used in training"""
+    return np.unique(np.concatenate([
+        np.array([0]),
+        np.int32(1.1**np.arange(1, np.ceil(np.log(train_steps)/np.log(1.1)))),
+        np.array([train_steps])
+    ]))
+
+def extract_filters(filename):
+    """Extract the number of filters from a filename"""
+    # Find the part that starts with 'filters_' and ends with '_g3'
+    start = filename.find('filters_') + len('filters_')
+    end = filename.find('_g3')
+    return int(filename[start:end])
+
+# Find all the pickle files and sort by filter number
+pickle_files = glob.glob("dana_normalized_mk3_metrics_history_steps_50000_filters_*_g3_iv=0.025_sv=0.0_p=-0.5_ts=1.0_delta=8.pkl")
+pickle_files.sort(key=extract_filters)
+
+# Extract all filter numbers to determine color mapping
+filter_numbers = [extract_filters(f) for f in pickle_files]
+min_filters = min(filter_numbers)
+max_filters = max(filter_numbers)
+
+plt.figure(figsize=(10, 6))
+
+# Create color mapping (shifted to avoid yellow)
+colors = plt.cm.plasma(np.linspace(0, 0.8, len(filter_numbers)))
+
+# Store final losses and flops for linear fit
+final_losses = []
+final_flops = []
+
+for idx, pickle_file in enumerate(pickle_files):
+    # Extract number of filters from filename
+    num_filters = extract_filters(pickle_file)
+    
+    # Skip the 32 filters case (outlier)
+    if num_filters == 32:
+        continue
+    
+    # Load the data
+    with open(pickle_file, 'rb') as f:
+        data = pickle.load(f)
+    
+    # Get the loss values
+    losses = data['train_loss']
+    
+    # Calculate the time points using the same sequence as training
+    times = generate_loss_times(STEPS)
+    # Make sure we have the same number of time points as loss values
+    times = times[:len(losses)]
+    # Scale by parameters and batch size
+    flops = times * count_parameters(num_filters) * BATCH_SIZE
+    
+    # Store final values for linear fit
+    final_losses.append(losses[-1])
+    final_flops.append(flops[-1])
+    
+    # Plot the data with color from plasma colormap
+    plt.loglog(flops, losses, label=f'Filters={num_filters}', color=colors[idx])
+
+# Perform linear fit on log-log data
+slope, intercept, r_value, p_value, std_err = stats.linregress(np.log10(final_flops), np.log10(final_losses))
+
+# Plot the fit line
+x_fit = np.array([min(final_flops), max(final_flops)])
+y_fit = 10**(slope * np.log10(x_fit) + intercept)
+plt.loglog(x_fit, y_fit, 'k--', label=f'Fit (slope={slope:.3f})')
+
+plt.xlabel('Flops')
+plt.ylabel('Training Loss')
+plt.title('Resnet-18 Training Loss vs Flops (DANA, p=-0.5)')
+plt.grid(True)
+plt.legend()
+plt.tight_layout()
+plt.savefig('dana_losses_comparison.pdf')
+plt.close() 

--- a/dana-nonquadratic-tests/cifar5m-resnet/plot_losses_comparison.py
+++ b/dana-nonquadratic-tests/cifar5m-resnet/plot_losses_comparison.py
@@ -1,0 +1,188 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import pickle
+import glob
+import os
+import scipy.stats as stats
+
+# Constants
+BATCH_SIZE = 128
+STEPS = 50000
+
+def count_parameters(num_filters):
+    """Calculate the number of parameters in the ResNet model for given number of filters"""
+    # Using the formula from the original code
+    return 44668662 * (num_filters**2) / (128**2)
+
+def generate_loss_times(train_steps):
+    """Generate the same time sequence as used in training"""
+    return np.unique(np.concatenate([
+        np.array([0]),
+        np.int32(1.1**np.arange(1, np.ceil(np.log(train_steps)/np.log(1.1)))),
+        np.array([train_steps])
+    ]))
+
+def extract_filters(filename):
+    """Extract the number of filters from a filename"""
+    # Find the part that starts with 'filters_' and ends with '_g3' or '.pkl'
+    start = filename.find('filters_') + len('filters_')
+    if '_g3' in filename:
+        end = filename.find('_g3')
+    else:
+        end = filename.find('.pkl')
+    return int(filename[start:end])
+
+def extract_iv(filename):
+    """Extract the initialization value (iv) from a filename"""
+    start = filename.find('iv=') + len('iv=')
+    end = filename.find('_sv=')
+    return float(filename[start:end])
+
+def plot_losses(pickle_files, title, output_file, use_colors=True):
+    """Generate a plot for the given files"""
+    plt.figure(figsize=(10, 6))
+    
+    # Create color mapping if needed
+    if use_colors:
+        colors = plt.cm.plasma(np.linspace(0, 0.8, len(pickle_files)))
+    
+    # Store final losses and flops for linear fit
+    final_losses = []
+    final_flops = []
+    
+    for idx, pickle_file in enumerate(pickle_files):
+        # Extract number of filters from filename
+        num_filters = extract_filters(pickle_file)
+        
+        # Skip the 32 filters case (outlier)
+        if num_filters == 32:
+            continue
+        
+        # Load the data
+        with open(pickle_file, 'rb') as f:
+            data = pickle.load(f)
+        
+        # Get the loss values
+        losses = data['train_loss']
+        
+        # Calculate the time points using the same sequence as training
+        times = generate_loss_times(STEPS)
+        # Make sure we have the same number of time points as loss values
+        times = times[:len(losses)]
+        # Scale by parameters and batch size
+        flops = times * count_parameters(num_filters) * BATCH_SIZE
+        
+        # Store final values for linear fit
+        final_losses.append(losses[-1])
+        final_flops.append(flops[-1])
+        
+        # Plot the data
+        if use_colors:
+            plt.loglog(flops, losses, label=f'Filters={num_filters}', color=colors[idx])
+        else:
+            plt.loglog(flops, losses, label=f'Filters={num_filters}')
+    
+    # Perform linear fit on log-log data
+    slope, intercept, r_value, p_value, std_err = stats.linregress(np.log10(final_flops), np.log10(final_losses))
+    
+    # Plot the fit line
+    x_fit = np.array([min(final_flops), max(final_flops)])
+    y_fit = 10**(slope * np.log10(x_fit) + intercept)
+    plt.loglog(x_fit, y_fit, 'k--', label=f'Fit (slope={slope:.3f})')
+    
+    plt.xlabel('Flops')
+    plt.ylabel('Training Loss')
+    plt.title(title)
+    plt.grid(True)
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(output_file)
+    plt.close()
+    
+    return final_flops, final_losses
+
+def plot_comparison(sgd_files, dana_files):
+    """Generate a comparison plot with both SGD and DANA results"""
+    plt.figure(figsize=(12, 8))
+    
+    # Store final losses and flops for both methods
+    final_losses_sgd = []
+    final_flops_sgd = []
+    final_losses_dana = []
+    final_flops_dana = []
+    
+    # Process SGD files
+    for pickle_file in sgd_files:
+        num_filters = extract_filters(pickle_file)
+        if num_filters == 32:  # Skip outlier
+            continue
+            
+        with open(pickle_file, 'rb') as f:
+            data = pickle.load(f)
+        losses = data['train_loss']
+        times = generate_loss_times(STEPS)[:len(losses)]
+        flops = times * count_parameters(num_filters) * BATCH_SIZE
+        
+        final_losses_sgd.append(losses[-1])
+        final_flops_sgd.append(flops[-1])
+        plt.loglog(flops, losses, color='blue', alpha=0.3, label=f'SGD (Filters={num_filters})' if num_filters == sgd_files[0] else None)
+    
+    # Process DANA files - group by filter size
+    filter_groups = {}
+    for pickle_file in dana_files:
+        num_filters = extract_filters(pickle_file)
+        if num_filters == 32:  # Skip outlier
+            continue
+            
+        if num_filters not in filter_groups:
+            filter_groups[num_filters] = []
+        filter_groups[num_filters].append(pickle_file)
+    
+    # Plot DANA curves grouped by filter size
+    colors = plt.cm.plasma(np.linspace(0, 0.8, len(filter_groups)))
+    for idx, (num_filters, group_files) in enumerate(filter_groups.items()):
+        for pickle_file in group_files:
+            with open(pickle_file, 'rb') as f:
+                data = pickle.load(f)
+            losses = data['train_loss']
+            times = generate_loss_times(STEPS)[:len(losses)]
+            flops = times * count_parameters(num_filters) * BATCH_SIZE
+            
+            final_losses_dana.append(losses[-1])
+            final_flops_dana.append(flops[-1])
+            
+            # Only add label for the first curve of each filter group
+            label = f'DANA (Filters={num_filters})' if pickle_file == group_files[0] else None
+            plt.loglog(flops, losses, color=colors[idx], alpha=0.3, label=label)
+    
+    # Fit lines for both methods
+    for flops, losses, color, label in [
+        (final_flops_sgd, final_losses_sgd, 'blue', 'SGD'),
+        (final_flops_dana, final_losses_dana, 'red', 'DANA')
+    ]:
+        slope, intercept, r_value, p_value, std_err = stats.linregress(np.log10(flops), np.log10(losses))
+        x_fit = np.array([min(flops), max(flops)])
+        y_fit = 10**(slope * np.log10(x_fit) + intercept)
+        plt.loglog(x_fit, y_fit, color=color, linestyle='--', label=f'{label} (slope={slope:.3f})')
+    
+    plt.xlabel('Flops')
+    plt.ylabel('Training Loss')
+    plt.title('Resnet-18 Training Loss vs Flops (SGD vs DANA Classic)')
+    plt.grid(True)
+    plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    plt.tight_layout()
+    plt.savefig('combined_comparison.pdf', bbox_inches='tight')
+    plt.close()
+
+# Find and sort all files
+sgd_files = glob.glob("sgd_metrics_history_steps_50000_filters_*.pkl")
+dana_files = glob.glob("dana_classic_metrics_history_steps_50000_filters_*_g3_iv=*_sv=0.0_p=0.0_ts=1.0_delta=8.pkl")
+sgd_files.sort(key=extract_filters)
+dana_files.sort(key=extract_filters)
+
+# Generate individual plots
+plot_losses(sgd_files, 'Resnet-18 Training Loss vs Flops (SGD)', 'sgd_losses_comparison.pdf')
+plot_losses(dana_files, 'Resnet-18 Training Loss vs Flops (DANA Classic)', 'dana_losses_comparison.pdf')
+
+# Generate comparison plot
+plot_comparison(sgd_files, dana_files) 

--- a/dana-nonquadratic-tests/cifar5m-resnet/plot_losses_comparison_dana_classic.py
+++ b/dana-nonquadratic-tests/cifar5m-resnet/plot_losses_comparison_dana_classic.py
@@ -1,0 +1,240 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import pickle
+import glob
+import os
+import scipy.stats as stats
+
+# Constants
+BATCH_SIZE = 128
+STEPS = 50000
+
+def count_parameters(num_filters):
+    """Calculate the number of parameters in the ResNet model for given number of filters"""
+    # Using the formula from the original code
+    return 44668662 * (num_filters**2) / (128**2)
+
+def generate_loss_times(train_steps):
+    """Generate the same time sequence as used in training"""
+    return np.unique(np.concatenate([
+        np.array([0]),
+        np.int32(1.1**np.arange(1, np.ceil(np.log(train_steps)/np.log(1.1)))),
+        np.array([train_steps])
+    ]))
+
+def extract_filters(filename):
+    """Extract the number of filters from a filename"""
+    # Find the part that starts with 'filters_' and ends with '_g3' or '.pkl'
+    start = filename.find('filters_') + len('filters_')
+    if '_g3' in filename:
+        end = filename.find('_g3')
+    else:
+        end = filename.find('.pkl')
+    return int(filename[start:end])
+
+def extract_iv(filename):
+    """Extract the initialization value (iv) from a filename"""
+    start = filename.find('iv=') + len('iv=')
+    end = filename.find('_sv=')
+    return float(filename[start:end])
+
+def find_crossing_points(curve1_flops, curve1_losses, curve2_flops, curve2_losses):
+    """Find the last crossing point between two curves"""
+    # Interpolate curve2 onto curve1's flops points
+    curve2_losses_interp = np.interp(curve1_flops, curve2_flops, curve2_losses)
+    
+    # Find where curve1 crosses below curve2
+    crossings = np.where(curve1_losses < curve2_losses_interp)[0]
+    
+    if len(crossings) == 0:
+        return None, None
+    
+    # Get the last crossing point
+    last_crossing = crossings[-1]
+    return curve1_flops[last_crossing], curve1_losses[last_crossing]
+
+def plot_losses(pickle_files, title, output_file, use_colors=True):
+    """Generate a plot for the given files"""
+    plt.figure(figsize=(10, 6))
+    
+    # Create color mapping if needed
+    if use_colors:
+        colors = plt.cm.plasma(np.linspace(0, 0.8, len(pickle_files)))
+    
+    # Store final losses and flops for linear fit
+    final_losses = []
+    final_flops = []
+    
+    for idx, pickle_file in enumerate(pickle_files):
+        # Extract number of filters from filename
+        num_filters = extract_filters(pickle_file)
+        
+        # Skip the 32 filters case (outlier)
+        if num_filters == 32:
+            continue
+        
+        # Load the data
+        with open(pickle_file, 'rb') as f:
+            data = pickle.load(f)
+        
+        # Get the loss values
+        losses = data['train_loss']
+        
+        # Calculate the time points using the same sequence as training
+        times = generate_loss_times(STEPS)
+        # Make sure we have the same number of time points as loss values
+        times = times[:len(losses)]
+        # Scale by parameters and batch size
+        flops = times * count_parameters(num_filters) * BATCH_SIZE
+        
+        # Store final values for linear fit
+        final_losses.append(losses[-1])
+        final_flops.append(flops[-1])
+        
+        # Plot the data
+        if use_colors:
+            plt.loglog(flops, losses, label=f'Filters={num_filters}', color=colors[idx])
+        else:
+            plt.loglog(flops, losses, label=f'Filters={num_filters}')
+    
+    # Perform linear fit on log-log data
+    slope, intercept, r_value, p_value, std_err = stats.linregress(np.log10(final_flops), np.log10(final_losses))
+    
+    # Plot the fit line
+    x_fit = np.array([min(final_flops), max(final_flops)])
+    y_fit = 10**(slope * np.log10(x_fit) + intercept)
+    plt.loglog(x_fit, y_fit, 'k--', label=f'Fit (slope={slope:.3f})')
+    
+    plt.xlabel('Flops')
+    plt.ylabel('Training Loss')
+    plt.title(title)
+    plt.grid(True)
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(output_file)
+    plt.close()
+    
+    return final_flops, final_losses
+
+def plot_comparison(sgd_files, dana_files):
+    """Generate a comparison plot with both SGD and DANA results"""
+    plt.figure(figsize=(12, 8))
+    
+    # Store final losses and flops for both methods
+    final_losses_sgd = []
+    final_flops_sgd = []
+    
+    # Process SGD files
+    for pickle_file in sgd_files:
+        num_filters = extract_filters(pickle_file)
+        if num_filters == 32:  # Skip outlier
+            continue
+            
+        with open(pickle_file, 'rb') as f:
+            data = pickle.load(f)
+        losses = data['train_loss']
+        times = generate_loss_times(STEPS)[:len(losses)]
+        flops = times * count_parameters(num_filters) * BATCH_SIZE
+        
+        final_losses_sgd.append(losses[-1])
+        final_flops_sgd.append(flops[-1])
+        plt.loglog(flops, losses, color='blue', alpha=0.3, label=f'SGD (Filters={num_filters})' if num_filters == sgd_files[0] else None)
+    
+    # Process DANA files - group by filter size
+    filter_groups = {}
+    for pickle_file in dana_files:
+        num_filters = extract_filters(pickle_file)
+        if num_filters == 32:  # Skip outlier
+            continue
+            
+        if num_filters not in filter_groups:
+            filter_groups[num_filters] = []
+        filter_groups[num_filters].append(pickle_file)
+    
+    # Plot DANA curves and find crossing points
+    colors = plt.cm.plasma(np.linspace(0, 0.8, len(filter_groups)))
+    
+    for idx, (num_filters, group_files) in enumerate(filter_groups.items()):
+        # Sort files by iv value (descending)
+        group_files.sort(key=extract_iv, reverse=True)
+        
+        # Plot all curves for this filter size
+        for pickle_file in group_files:
+            with open(pickle_file, 'rb') as f:
+                data = pickle.load(f)
+            losses = data['train_loss']
+            times = generate_loss_times(STEPS)[:len(losses)]
+            flops = times * count_parameters(num_filters) * BATCH_SIZE
+            
+            # Only add label for the first curve of each filter group
+            label = f'DANA (Filters={num_filters})' if pickle_file == group_files[0] else None
+            plt.loglog(flops, losses, color=colors[idx], alpha=0.3, label=label)
+        
+        # Find crossing points between consecutive curves for this filter size
+        crossing_points_flops = []
+        crossing_points_losses = []
+        
+        for i in range(len(group_files) - 1):
+            file1 = group_files[i]
+            file2 = group_files[i + 1]
+            
+            with open(file1, 'rb') as f:
+                data1 = pickle.load(f)
+            with open(file2, 'rb') as f:
+                data2 = pickle.load(f)
+            
+            losses1 = data1['train_loss']
+            losses2 = data2['train_loss']
+            times1 = generate_loss_times(STEPS)[:len(losses1)]
+            times2 = generate_loss_times(STEPS)[:len(losses2)]
+            flops1 = times1 * count_parameters(num_filters) * BATCH_SIZE
+            flops2 = times2 * count_parameters(num_filters) * BATCH_SIZE
+            
+            # Find the last crossing point
+            crossing_flops, crossing_losses = find_crossing_points(flops1, losses1, flops2, losses2)
+            if crossing_flops is not None:
+                crossing_points_flops.append(crossing_flops)
+                crossing_points_losses.append(crossing_losses)
+                plt.plot(crossing_flops, crossing_losses, 'ko', color=colors[idx])
+        
+        # Fit line through crossing points for this filter size
+        if crossing_points_flops:
+            slope, intercept, r_value, p_value, std_err = stats.linregress(
+                np.log10(crossing_points_flops), 
+                np.log10(crossing_points_losses)
+            )
+            x_fit = np.array([min(crossing_points_flops), max(crossing_points_flops)])
+            y_fit = 10**(slope * np.log10(x_fit) + intercept)
+            plt.loglog(x_fit, y_fit, color=colors[idx], linestyle='--', 
+                      label=f'DANA Fit (Filters={num_filters}, slope={slope:.3f})')
+    
+    # Fit line for SGD
+    slope, intercept, r_value, p_value, std_err = stats.linregress(
+        np.log10(final_flops_sgd), 
+        np.log10(final_losses_sgd)
+    )
+    x_fit = np.array([min(final_flops_sgd), max(final_flops_sgd)])
+    y_fit = 10**(slope * np.log10(x_fit) + intercept)
+    plt.loglog(x_fit, y_fit, 'b--', label=f'SGD Fit (slope={slope:.3f})')
+    
+    plt.xlabel('Flops')
+    plt.ylabel('Training Loss')
+    plt.title('Resnet-18 Training Loss vs Flops (SGD vs DANA Classic)')
+    plt.grid(True)
+    plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    plt.tight_layout()
+    plt.savefig('combined_comparison_dana_classic.pdf', bbox_inches='tight')
+    plt.close()
+
+# Find and sort all files
+sgd_files = glob.glob("sgd_metrics_history_steps_50000_filters_*.pkl")
+dana_files = glob.glob("dana_classic_metrics_history_steps_50000_filters_*_g3_iv=*_sv=0.0_p=0.0_ts=1.0_delta=8.pkl")
+sgd_files.sort(key=extract_filters)
+dana_files.sort(key=extract_filters)
+
+# Generate individual plots
+plot_losses(sgd_files, 'Resnet-18 Training Loss vs Flops (SGD)', 'sgd_losses_comparison.pdf')
+plot_losses(dana_files, 'Resnet-18 Training Loss vs Flops (DANA Classic)', 'dana_classic_losses_comparison.pdf')
+
+# Generate comparison plot
+plot_comparison(sgd_files, dana_files) 

--- a/dana-nonquadratic-tests/cifar5m-resnet/plot_sgd_losses.py
+++ b/dana-nonquadratic-tests/cifar5m-resnet/plot_sgd_losses.py
@@ -1,0 +1,87 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import pickle
+import glob
+import os
+import scipy.stats as stats
+
+# Constants
+BATCH_SIZE = 128
+STEPS = 50000
+
+def count_parameters(num_filters):
+    """Calculate the number of parameters in the ResNet model for given number of filters"""
+    # Using the formula from the original code
+    return 44668662 * (num_filters**2) / (128**2)
+
+def generate_loss_times(train_steps):
+    """Generate the same time sequence as used in training"""
+    return np.unique(np.concatenate([
+        np.array([0]),
+        np.int32(1.1**np.arange(1, np.ceil(np.log(train_steps)/np.log(1.1)))),
+        np.array([train_steps])
+    ]))
+
+# Find all the pickle files and sort by filter number
+pickle_files = glob.glob("sgd_metrics_history_steps_50000_filters_*.pkl")
+pickle_files.sort(key=lambda x: int(x.split('_')[-1].split('.')[0]))
+
+# Extract all filter numbers to determine color mapping
+filter_numbers = [int(f.split('_')[-1].split('.')[0]) for f in pickle_files]
+min_filters = min(filter_numbers)
+max_filters = max(filter_numbers)
+
+plt.figure(figsize=(10, 6))
+
+# Create color mapping (shifted to avoid yellow)
+colors = plt.cm.plasma(np.linspace(0, 0.8, len(filter_numbers)))
+
+# Store final losses and flops for linear fit
+final_losses = []
+final_flops = []
+
+for idx, pickle_file in enumerate(pickle_files):
+    # Extract number of filters from filename
+    num_filters = int(pickle_file.split('_')[-1].split('.')[0])
+    
+    # Skip the 32 filters case (outlier)
+    if num_filters == 32:
+        continue
+    
+    # Load the data
+    with open(pickle_file, 'rb') as f:
+        data = pickle.load(f)
+    
+    # Get the loss values
+    losses = data['train_loss']
+    
+    # Calculate the time points using the same sequence as training
+    times = generate_loss_times(STEPS)
+    # Make sure we have the same number of time points as loss values
+    times = times[:len(losses)]
+    # Scale by parameters and batch size
+    flops = times * count_parameters(num_filters) * BATCH_SIZE
+    
+    # Store final values for linear fit
+    final_losses.append(losses[-1])
+    final_flops.append(flops[-1])
+    
+    # Plot the data with color from plasma colormap
+    plt.loglog(flops, losses, label=f'Filters={num_filters}', color=colors[idx])
+
+# Perform linear fit on log-log data
+slope, intercept, r_value, p_value, std_err = stats.linregress(np.log10(final_flops), np.log10(final_losses))
+
+# Plot the fit line
+x_fit = np.array([min(final_flops), max(final_flops)])
+y_fit = 10**(slope * np.log10(x_fit) + intercept)
+plt.loglog(x_fit, y_fit, 'k--', label=f'Fit (slope={slope:.3f})')
+
+plt.xlabel('Flops')
+plt.ylabel('Training Loss')
+plt.title('Resnet-18 Training Loss vs Flops')
+plt.grid(True)
+plt.legend()
+plt.tight_layout()
+plt.savefig('sgd_losses_comparison.pdf')
+plt.close() 

--- a/dana-nonquadratic-tests/lstm-1b/README.md
+++ b/dana-nonquadratic-tests/lstm-1b/README.md
@@ -1,0 +1,12 @@
+This is an experiment to get DANA working on an lstm training task on the million-word dataset.
+
+This is a reimplementation of the work of https://github.com/rafaljozefowicz/lm 
+
+It uses the 1b_word_vocab.txt file from that repository https://github.com/rafaljozefowicz/lm/1b_word_vocab.txt.
+
+It also uses the 1 Billion Word Language Model Benchmark: https://www.statmt.org/lm-benchmark/  
+See also the paper of Chelba et al. : https://arxiv.org/abs/1312.3005
+
+Plotting code is in dana_powerlaw_fits.py and plot_all_dana_curves.py (for comparison curves across various alpha)
+
+

--- a/dana-nonquadratic-tests/lstm-1b/dana_powerlaw_fits.py
+++ b/dana-nonquadratic-tests/lstm-1b/dana_powerlaw_fits.py
@@ -1,0 +1,184 @@
+import os
+import glob
+import pickle
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import scipy.stats as stats
+
+# Configuration
+RESULTS_DIR = "results"
+BATCH_SIZE = 128
+NUM_STEPS = 20
+TRAIN_STEPS = 100000
+NUM_LAYERS = 2
+HIDDEN_SIZE = 1024
+EMB_SIZE = 512
+LEARNING_RATE = 0.1
+MAX_GRAD_NORM = 10.0
+KEEP_PROB = 0.9
+MAX_TOKENS = None
+
+# DANA optimizer parameters
+DANA_G3_IV = 0.5
+DANA_G3_SV = 0.0
+DANA_G3_P = -0.5
+DANA_G3_TS = 1.0
+DANA_DELTA = 8
+
+def fit_power_law(tokens, values):
+    """Fit a power law to the data.
+    
+    Args:
+        tokens: Array of token counts
+        values: Array of values to fit
+        
+    Returns:
+        A: Amplitude of the power law
+        beta: Exponent of the power law
+        fit_values: Fitted values
+        r_value: R-squared value of the fit
+    """
+    # Convert to numpy arrays
+    tokens = np.array(tokens)
+    values = np.array(values)
+    
+    # Fit power law: value = A * (tokens)^beta
+    log_tokens = np.log(tokens)
+    log_values = np.log(values)
+    
+    # Linear fit in log-log space
+    slope, intercept, r_value, p_value, std_err = stats.linregress(log_tokens, log_values)
+    
+    # Power law parameters: value = A * tokens^beta
+    A = np.exp(intercept)
+    beta = slope
+    fit_values = A * (tokens ** beta)
+    
+    return A, beta, fit_values, r_value
+
+def create_dana_powerlaw_plot():
+    """Create a plot of DANA and SGD perplexity curves with power law fits."""
+    # Find the DANA metrics file
+    dana_metrics_filename = (
+        f"{RESULTS_DIR}/dana_metrics_history_steps_{TRAIN_STEPS}_layers_{NUM_LAYERS}_"
+        f"hidden_{HIDDEN_SIZE}_emb_{EMB_SIZE}_lr_{LEARNING_RATE}_maxgrad_{MAX_GRAD_NORM}_"
+        f"keep_{KEEP_PROB}_maxtokens_{MAX_TOKENS}_g3_iv={DANA_G3_IV}_sv={DANA_G3_SV}_"
+        f"p={DANA_G3_P}_ts={DANA_G3_TS}_delta={DANA_DELTA}.pkl"
+    )
+    
+    # Find the SGD metrics file
+    sgd_metrics_filename = (
+        f"{RESULTS_DIR}/sgd_metrics_history_steps_{TRAIN_STEPS}_layers_{NUM_LAYERS}_"
+        f"hidden_{HIDDEN_SIZE}_emb_{EMB_SIZE}_lr_{LEARNING_RATE}_maxgrad_{MAX_GRAD_NORM}_"
+        f"keep_{KEEP_PROB}_maxtokens_{MAX_TOKENS}.pkl"
+    )
+    
+    # Load the DANA metrics
+    print(f"Loading DANA metrics from {dana_metrics_filename}")
+    with open(dana_metrics_filename, "rb") as f:
+        saved_config, dana_loss_times, dana_metrics_history, num_params = pickle.load(f)
+    
+    # Load the SGD metrics
+    print(f"Loading SGD metrics from {sgd_metrics_filename}")
+    with open(sgd_metrics_filename, "rb") as f:
+        saved_config, sgd_loss_times, sgd_metrics_history, _ = pickle.load(f)
+    
+    # Print debug information
+    print("\nArray shapes:")
+    print(f"dana_loss_times: {len(dana_loss_times)}")
+    print(f"sgd_loss_times: {len(sgd_loss_times)}")
+    for key in dana_metrics_history:
+        print(f"{key}: {len(dana_metrics_history[key])}")
+    
+    # Create the figure
+    fig, ax = plt.subplots(figsize=(12, 8))
+    
+    # Skip step 0 and convert to tokens
+    skip = 1
+    # Get the length of the data arrays
+    data_length = len(dana_metrics_history['train_perplexity'])
+    # Trim tokens array to match data length
+    dana_tokens = np.array(dana_loss_times[skip:skip+data_length]) * BATCH_SIZE * NUM_STEPS
+    sgd_tokens = np.array(sgd_loss_times[skip:skip+data_length]) * BATCH_SIZE * NUM_STEPS
+    
+    print(f"\nTokens shape after trimming: {dana_tokens.shape}")
+    
+    # Calculate the midpoint for using only the second half of the data
+    midpoint = len(dana_tokens) // 2
+    
+    # Add vertical line at midpoint
+    midpoint_tokens = dana_tokens[midpoint]
+    ax.axvline(x=midpoint_tokens, color='gray', linestyle=':', alpha=0.5, 
+               label='Fit start point')
+    
+    # Colors and line styles for the different curves
+    colors = {
+        'dana_train': 'blue',
+        'dana_val': 'red',
+        'sgd_train': 'lightblue',
+        'sgd_val': 'pink'
+    }
+    
+    # Plot DANA and SGD perplexity curves and fit power laws
+    for optimizer, metrics in [('dana', dana_metrics_history), ('sgd', sgd_metrics_history)]:
+        tokens = dana_tokens if optimizer == 'dana' else sgd_tokens
+        
+        for dataset in ('train_perplexity', 'val_perplexity'):
+            # Get data
+            data = np.array(metrics[dataset])
+            print(f"\n{optimizer} {dataset} shape: {data.shape}")
+            
+            # Plot the actual data
+            color = colors[f'{optimizer}_{dataset.split("_")[0]}']
+            ax.loglog(tokens, data, 'o-', color=color, 
+                     label=f'{optimizer.upper()} {dataset.split("_")[0]}', 
+                     alpha=0.7, markersize=4)
+            
+            # Fit power law using only the second half of the data
+            if len(tokens[midpoint:]) > 2:  # Need at least 3 points for a fit
+                A, beta, fit_values, r_value = fit_power_law(tokens[midpoint:], data[midpoint:])
+                
+                # Plot the fit
+                ax.loglog(tokens[midpoint:], fit_values, '--', color=color, 
+                         label=f'{optimizer.upper()} {dataset.split("_")[0]} fit: {A:.2f} * m^({beta:.3f}), R²={r_value**2:.3f}', 
+                         alpha=1.0, linewidth=2)
+    
+    # Add horizontal and vertical grid lines
+    ax.grid(True, which='both', axis='both', linestyle='--', alpha=0.7)
+    
+    # Set more y-axis ticks
+    ax.yaxis.set_major_formatter(ticker.FormatStrFormatter('%.3g'))
+    
+    # Set axis labels
+    ax.set_xlabel('Training Tokens (millions)')
+    ax.set_ylabel('Perplexity')
+    
+    # Convert x-axis to millions
+    ax.xaxis.set_major_formatter(ticker.FuncFormatter(lambda x, pos: f'{x/1e6:.1f}'))
+    
+    # Add legend with two columns and smaller font
+    ax.legend(loc='upper right', bbox_to_anchor=(1, 1), ncol=2, fontsize='small')
+    
+    # Add title
+    fig.suptitle(f"DANA vs SGD Perplexity Curves ({num_params:,} parameters)\n" + 
+                 f"DANA decay with exponent -0.5 (alpha=1.0)\n" + 
+                 f"2-layer LSTM (4-layer network), 1024 hidden, 512 embedding",
+                 y=0.95)
+    
+    # Generate output filename
+    output_filename = (
+        f"{RESULTS_DIR}/dana_sgd_perplexity_fits_steps_{TRAIN_STEPS}_layers_{NUM_LAYERS}_"
+        f"hidden_{HIDDEN_SIZE}_emb_{EMB_SIZE}_lr_{LEARNING_RATE}_"
+        f"keep_{KEEP_PROB}_maxtokens_{MAX_TOKENS}_g3_iv={DANA_G3_IV}_sv={DANA_G3_SV}_"
+        f"p={DANA_G3_P}_ts={DANA_G3_TS}_delta={DANA_DELTA}.pdf"
+    )
+    
+    # Adjust layout to prevent legend cutoff
+    plt.subplots_adjust(right=0.85)
+    plt.savefig(output_filename, bbox_inches='tight')
+    
+    print(f"\nDANA vs SGD perplexity fits plot saved to {output_filename}")
+
+if __name__ == "__main__":
+    create_dana_powerlaw_plot() 

--- a/dana-nonquadratic-tests/lstm-1b/flax-billion-word-lstm.py
+++ b/dana-nonquadratic-tests/lstm-1b/flax-billion-word-lstm.py
@@ -1,0 +1,1278 @@
+import os
+import glob
+import codecs
+import random
+import time
+import math
+import pickle
+import sys
+from typing import Dict, List, Tuple, Any, Optional, Callable
+
+import jax
+import jax.numpy as jnp
+from jax import random as jrandom
+import numpy as np
+from flax import nnx
+from flax.nnx import rnglib
+import optax
+from tqdm import tqdm
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import scipy.stats as stats
+import tensorflow as tf
+
+# Disable GPU for TensorFlow to avoid conflicts with JAX
+tf.config.set_visible_devices([], 'GPU')
+print("TensorFlow GPU access disabled")
+
+# Import optimizers for DANA
+sys.path.append('../../')
+import optimizers
+
+# Configuration
+import argparse
+
+# Default configuration
+DEFAULT_CONFIG = {
+    "batch_size": 128,
+    "num_steps": 20,  # Sequence length
+    "train_steps": 10000,  # For full run; use 100 for debugging
+    "vocab_size": 10000,  # Top 10k words as mentioned in the paper
+    "emb_size": 32,  # Paper mentions 512
+    "hidden_size": 64,  # Paper mentions 1024
+    "num_layers": 2,  # Paper mentions 2-layer and 4-layer LSTMs
+    "learning_rate": 0.1,
+    "max_grad_norm": 10.0,
+    "keep_prob": 0.9,  # Dropout keep probability
+    "base_path": "/home/elliotpaquette/Documents/BillionWords",
+    "max_tokens": 0,  # For debugging, set to 0 for full dataset
+    # DANA optimizer parameters
+    "max_val_tokens": 10000,  # For validation, set to 0 for full dataset
+    "optimizer": "sgd",  # 'sgd' or 'dana'
+    "population_trace": 4.0,  # For DANA optimizer
+    "dana_g3_iv": 0.5,  # Initial value for g3 in DANA
+    "dana_g3_sv": 0.0,  # Saturation value for g3 in DANA
+    "dana_g3_p": -1.0,  # Power for g3 in DANA
+    "dana_g3_ts": 1.0,  # Time scale for g3 in DANA
+    "dana_delta": 8,  # Delta parameter for DANA
+    "results_dir": "results",  # Directory to store results
+}
+
+# Parse command-line arguments
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train an LSTM language model on the Billion Word Dataset")
+    parser.add_argument("--batch_size", type=int, default=DEFAULT_CONFIG["batch_size"], help="Batch size")
+    parser.add_argument("--num_steps", type=int, default=DEFAULT_CONFIG["num_steps"], help="Sequence length")
+    parser.add_argument("--train_steps", type=int, default=DEFAULT_CONFIG["train_steps"], help="Number of training steps")
+    parser.add_argument("--vocab_size", type=int, default=DEFAULT_CONFIG["vocab_size"], help="Vocabulary size (top N words)")
+    parser.add_argument("--emb_size", type=int, default=DEFAULT_CONFIG["emb_size"], help="Embedding dimension")
+    parser.add_argument("--hidden_size", type=int, default=DEFAULT_CONFIG["hidden_size"], help="Hidden layer size")
+    parser.add_argument("--num_layers", type=int, default=DEFAULT_CONFIG["num_layers"], help="Number of LSTM layers")
+    parser.add_argument("--learning_rate", type=float, default=DEFAULT_CONFIG["learning_rate"], help="Learning rate")
+    parser.add_argument("--max_grad_norm", type=float, default=DEFAULT_CONFIG["max_grad_norm"], help="Maximum gradient norm for clipping")
+    parser.add_argument("--keep_prob", type=float, default=DEFAULT_CONFIG["keep_prob"], help="Dropout keep probability")
+    parser.add_argument("--base_path", type=str, default=DEFAULT_CONFIG["base_path"], help="Base path for data")
+    parser.add_argument("--max_tokens", type=int, default=DEFAULT_CONFIG["max_tokens"], help="Maximum number of tokens to use (None for all)")
+    parser.add_argument("--max_val_tokens", type=int, default=DEFAULT_CONFIG["max_val_tokens"], help="Maximum number of validation tokens to use (None for all)")
+
+    # DANA optimizer parameters
+    parser.add_argument("--optimizer", type=str, default=DEFAULT_CONFIG["optimizer"], choices=["sgd", "dana"],
+                        help="Optimizer to use (sgd or dana)")
+    parser.add_argument("--population_trace", type=float, default=DEFAULT_CONFIG["population_trace"],
+                        help="Population trace for DANA optimizer")
+    parser.add_argument("--dana_g3_iv", type=float, default=DEFAULT_CONFIG["dana_g3_iv"],
+                        help="Initial value for g3 in DANA")
+    parser.add_argument("--dana_g3_sv", type=float, default=DEFAULT_CONFIG["dana_g3_sv"],
+                        help="Saturation value for g3 in DANA")
+    parser.add_argument("--dana_g3_p", type=float, default=DEFAULT_CONFIG["dana_g3_p"],
+                        help="Power for g3 in DANA")
+    parser.add_argument("--dana_g3_ts", type=float, default=DEFAULT_CONFIG["dana_g3_ts"],
+                        help="Time scale for g3 in DANA")
+    parser.add_argument("--dana_delta", type=float, default=DEFAULT_CONFIG["dana_delta"],
+                        help="Delta parameter for DANA")
+    parser.add_argument("--results_dir", type=str, default=DEFAULT_CONFIG["results_dir"],
+                        help="Directory to store results")
+    
+    return parser.parse_args()
+
+# Set global configuration variables
+args = parse_args()
+BATCH_SIZE = args.batch_size
+NUM_STEPS = args.num_steps
+TRAIN_STEPS = args.train_steps
+VOCAB_SIZE = args.vocab_size
+EMB_SIZE = args.emb_size
+HIDDEN_SIZE = args.hidden_size
+NUM_LAYERS = args.num_layers
+LEARNING_RATE = args.learning_rate
+MAX_GRAD_NORM = args.max_grad_norm
+KEEP_PROB = args.keep_prob
+BASE_PATH = args.base_path
+MAX_TOKENS = args.max_tokens if args.max_tokens > 0 else None
+MAX_VAL_TOKENS = args.max_val_tokens if args.max_val_tokens > 0 else None
+# DANA optimizer parameters
+OPTIMIZER = args.optimizer
+POPULATION_TRACE = args.population_trace
+DANA_G3_IV = args.dana_g3_iv
+DANA_G3_SV = args.dana_g3_sv
+DANA_G3_P = args.dana_g3_p
+DANA_G3_TS = args.dana_g3_ts
+DANA_DELTA = args.dana_delta
+RESULTS_DIR = args.results_dir
+
+# Create results directory if it doesn't exist
+os.makedirs(RESULTS_DIR, exist_ok=True)
+
+# Derived paths
+VOCAB_FILE = f"{BASE_PATH}/1b_word_vocab.txt"
+DATA_PATH = f"{BASE_PATH}/training-monolingual"
+
+# Set up logging
+EVAL_INTERVAL = 100
+LOG_STEPS = jnp.unique(jnp.concatenate([
+    jnp.array([0]),
+    jnp.int32(1.1**jnp.arange(1, jnp.ceil(jnp.log(TRAIN_STEPS)/jnp.log(1.1)))),
+    jnp.array([TRAIN_STEPS])
+]))
+
+# Function for printing log messages that should appear in both console and log files
+def log_print(message):
+    """Print a message to stdout and ensure it appears in log files too."""
+    # Use print() instead of tqdm.write() when tqdm is disabled
+    if os.environ.get('TQDM_DISABLE') == '1':
+        print(message)
+    else:
+        tqdm.write(message)
+
+class Vocabulary:
+    """Vocabulary class for handling word-to-id mapping."""
+    
+    def __init__(self):
+        self._token_to_id = {}
+        self._id_to_token = []
+        self._token_to_count = {}
+        self._num_tokens = 0
+        self._s_id = None
+        self._unk_id = None
+    
+    @property
+    def num_tokens(self):
+        return self._num_tokens
+    
+    @property
+    def unk(self):
+        return "<UNK>"
+    
+    @property
+    def unk_id(self):
+        return self._unk_id
+    
+    @property
+    def s(self):
+        return "<S>"
+    
+    @property
+    def s_id(self):
+        return self._s_id
+    
+    def add(self, token, count):
+        self._token_to_id[token] = self._num_tokens
+        self._token_to_count[token] = count
+        self._id_to_token.append(token)
+        self._num_tokens += 1
+    
+    def finalize(self):
+        self._s_id = self.get_id(self.s)
+        self._unk_id = self.get_id(self.unk)
+    
+    def get_id(self, token):
+        return self._token_to_id.get(token, self._unk_id)
+    
+    def get_token(self, id_):
+        return self._id_to_token[id_]
+    
+    @staticmethod
+    def from_file(filename, max_vocab_size=None):
+        vocab = Vocabulary()
+        with codecs.open(filename, "r", "utf-8") as f:
+            for i, line in enumerate(f):
+                if max_vocab_size is not None and i >= max_vocab_size:
+                    break
+                word, count = line.strip().split()
+                vocab.add(word, int(count))
+        vocab.finalize()
+        return vocab
+
+class Dataset:
+    """
+    Dataset class for handling language model data.
+    UNUSED - see TFDataset below
+    """
+    
+    def __init__(self, vocab, file_pattern, deterministic=False, max_tokens=None):
+        self._vocab = vocab
+        self._file_pattern = file_pattern
+        self._deterministic = deterministic
+        self._max_tokens = max_tokens
+        self._total_tokens = 0
+        
+        # Load all sentences at initialization to ensure we have data
+        self._all_sentences = []
+        for file_name in glob.glob(self._file_pattern):
+            with codecs.open(file_name, "r", "utf-8") as f:
+                lines = [line.strip() for line in f]
+                if not self._deterministic:
+                    random.shuffle(lines)
+                for line in lines:
+                    if line:
+                        sentence = self._parse_sentence(line)
+                        self._all_sentences.append(sentence)
+                        self._total_tokens += len(sentence)
+                        if self._max_tokens is not None and self._total_tokens >= self._max_tokens:
+                            break
+            if self._max_tokens is not None and self._total_tokens >= self._max_tokens:
+                break
+        
+        print(f"Loaded {len(self._all_sentences)} sentences with {self._total_tokens} tokens")
+    
+    def _parse_sentence(self, line):
+        s_id = self._vocab.s_id
+        return [s_id] + [self._vocab.get_id(word) for word in line.strip().split()] + [s_id]
+    
+    def _iterate(self, batch_size, num_steps):
+        # Create a copy of the sentences to avoid modifying the original
+        sentences = self._all_sentences.copy()
+        if not self._deterministic:
+            random.shuffle(sentences)
+        
+        streams = [None] * batch_size
+        x = np.zeros([batch_size, num_steps], np.int32)
+        y = np.zeros([batch_size, num_steps], np.int32)
+        w = np.zeros([batch_size, num_steps], np.uint8)
+        
+        sentence_idx = 0
+        
+        while True:
+            x[:] = 0
+            y[:] = 0
+            w[:] = 0
+            
+            for i in range(batch_size):
+                tokens_filled = 0
+                while tokens_filled < num_steps:
+                    if streams[i] is None or len(streams[i]) <= 1:
+                        if sentence_idx >= len(sentences):
+                            # No more sentences
+                            break
+                        streams[i] = sentences[sentence_idx]
+                        sentence_idx += 1
+                    
+                    num_tokens = min(len(streams[i]) - 1, num_steps - tokens_filled)
+                    x[i, tokens_filled:tokens_filled+num_tokens] = streams[i][:num_tokens]
+                    y[i, tokens_filled:tokens_filled+num_tokens] = streams[i][1:num_tokens+1]
+                    w[i, tokens_filled:tokens_filled+num_tokens] = 1
+                    streams[i] = streams[i][num_tokens:]
+                    tokens_filled += num_tokens
+            
+            if not np.any(w):
+                # No more data
+                return
+            
+            yield jnp.array(x), jnp.array(y), jnp.array(w)
+    
+    def iterate_once(self, batch_size, num_steps):
+        for value in self._iterate(batch_size, num_steps):
+            yield value
+
+class TFDataset:
+    """TensorFlow Dataset implementation for handling language model data.
+    
+    This implementation uses tf.data.TextLineDataset to load data efficiently, without
+    loading all files in memory. It allows streaming of training data and caching of
+    validation data.
+    """
+    
+    def __init__(self, vocab, file_pattern, batch_size, num_steps, deterministic=False, max_tokens=None, is_validation=False):
+        """Initialize TensorFlow Dataset for language model.
+        
+        Args:
+            vocab: Vocabulary object
+            file_pattern: File pattern or specific file to load
+            batch_size: Batch size for the dataset
+            num_steps: Number of steps (sequence length)
+            deterministic: Whether to use deterministic processing (no shuffling)
+            max_tokens: Maximum number of tokens to use
+            is_validation: Whether this is a validation dataset (for caching)
+        """
+        print(f"{'Validation' if is_validation else 'Training'} Dataset: Initializing with max_tokens={max_tokens or 'unlimited'}")
+        start_time = time.time()
+        
+        self._vocab = vocab
+        self._file_pattern = file_pattern
+        self._batch_size = batch_size
+        self._num_steps = num_steps
+        self._deterministic = deterministic
+        self._max_tokens = max_tokens
+        self._is_validation = is_validation
+        self._total_tokens = 0
+        
+        # Resolve file pattern to actual files
+        if isinstance(file_pattern, str) and "*" in file_pattern:
+            print(f"Resolving glob pattern: {file_pattern}")
+            self._files = sorted(glob.glob(file_pattern))
+        elif isinstance(file_pattern, str):
+            self._files = [file_pattern]
+        else:
+            self._files = list(file_pattern)
+            
+        if not self._files:
+            raise ValueError(f"No files found matching pattern: {file_pattern}")
+        
+        print(f"Found {len(self._files)} files for {'validation' if self._is_validation else 'training'}")
+        
+        # For validation, just use one file to keep consistent with original implementation
+        if self._is_validation and len(self._files) > 1:
+            self._files = [self._files[-1]]  # Use last file for validation
+            print(f"Using only 1 file for validation: {self._files[0]}")
+            
+        # Print file sizes to give an idea of how much data we're loading
+        total_size_mb = 0
+        for file in self._files:
+            size_mb = os.path.getsize(file) / (1024 * 1024)
+            total_size_mb += size_mb
+            print(f"  - {file}: {size_mb:.2f} MB")
+        print(f"Total size: {total_size_mb:.2f} MB")
+        
+        # Create the TensorFlow dataset pipeline
+        print(f"Creating TensorFlow dataset pipeline...")
+        self._tf_dataset = self._create_tf_dataset()
+        
+        # For validation, cache the dataset after preprocessing
+        if self._is_validation:
+            print("Caching validation dataset...")
+            self._tf_dataset = self._tf_dataset.cache()
+            
+            # Calculate total tokens in validation set for reporting
+            print("Calculating validation token count...")
+            token_count = 0
+            batch_count = 0
+            for batch in self._tf_dataset:
+                x, y, w = batch
+                token_count += tf.reduce_sum(w)
+                batch_count += 1
+                if batch_count % 10 == 0:
+                    print(f"  Processed {batch_count} validation batches, {token_count.numpy()} tokens so far")
+                if self._max_tokens is not None and token_count >= self._max_tokens:
+                    break
+            
+            self._total_validation_tokens = int(min(token_count.numpy(), self._max_tokens or float('inf')))
+            print(f"Validation dataset contains approximately {self._total_validation_tokens} tokens in {batch_count} batches")
+        
+        # Report initialization time
+        elapsed = time.time() - start_time
+        print(f"{'Validation' if is_validation else 'Training'} dataset initialization completed in {elapsed:.2f} seconds")
+    
+    def _parse_line(self, line):
+        """Parse a text line into token IDs.
+        
+        Args:
+            line: A string tensor containing a line of text
+            
+        Returns:
+            A list of token IDs
+        """
+        s_id = self._vocab.s_id
+        
+        # Skip empty lines
+        if tf.strings.length(line) <= 0:
+            return tf.constant([s_id, s_id], dtype=tf.int32)
+        
+        # Split line into words
+        words = tf.strings.split(line)
+        
+        # Convert each word to its token ID using a py_function
+        # (needed because vocabulary lookup is not a TensorFlow operation)
+        token_ids = tf.py_function(
+            lambda x: np.array([self._vocab.get_id(word.decode('utf-8')) for word in x.numpy()], dtype=np.int32),
+            [words],
+            tf.int32
+        )
+        
+        # Add start and end tokens
+        token_ids = tf.concat([[s_id], token_ids, [s_id]], axis=0)
+        
+        return token_ids
+    
+    def _create_tf_dataset(self):
+        """Create a TensorFlow dataset pipeline for efficient processing.
+        
+        Returns:
+            A tf.data.Dataset that yields (inputs, targets, weights) batches
+        """
+        start_time = time.time()
+        
+        # Create dataset from file list
+        print("Creating dataset from files...")
+        files_ds = tf.data.Dataset.from_tensor_slices(self._files)
+        
+        # Shuffle file order for training (but not for validation)
+        if not self._deterministic:
+            print("Shuffling files...")
+            files_ds = files_ds.shuffle(buffer_size=len(self._files))
+        
+        # Load text lines from files, interleaving for better performance
+        print("Setting up interleaved file reading...")
+        lines_ds = files_ds.interleave(
+            lambda file: tf.data.TextLineDataset(file).filter(lambda line: tf.strings.length(line) > 0),
+            cycle_length=4,
+            block_length=16,
+            num_parallel_calls=tf.data.AUTOTUNE
+        )
+        
+        # Parse lines into token sequences
+        print("Setting up tokenization...")
+        tokens_ds = lines_ds.map(
+            self._parse_line,
+            num_parallel_calls=tf.data.AUTOTUNE
+        )
+        
+        # For training, shuffle the sequences
+        if not self._deterministic:
+            print("Setting up sequence shuffling...")
+            tokens_ds = tokens_ds.shuffle(buffer_size=10000)
+        
+        # Create a dataset of token streams for batching
+        print("Flattening tokens into a continuous stream...")
+        # This approach concatenates all tokens and then creates sliding windows
+        token_stream_ds = tokens_ds.flat_map(
+            lambda x: tf.data.Dataset.from_tensor_slices(x)
+        )
+        
+        # Apply max_tokens limit if specified
+        if self._max_tokens is not None:
+            print(f"Setting token limit to {self._max_tokens}")
+            token_stream_ds = token_stream_ds.take(self._max_tokens + self._batch_size * self._num_steps)
+        else:
+            print("No token limit set - will use all available data")
+        
+        # Create windows of size num_steps + 1 (for input and target)
+        print(f"Creating windows of size {self._num_steps + 1}...")
+        # with stride of 1 to get all possible windows
+        windows_ds = token_stream_ds.window(
+            size=self._num_steps + 1,
+            shift=self._num_steps,
+            drop_remainder=True
+        )
+        
+        # Convert windows to tensors
+        print("Converting windows to tensors...")
+        windows_ds = windows_ds.map(
+            lambda window: tf.data.experimental.get_single_element(
+                window.batch(self._num_steps + 1)
+            ),
+            num_parallel_calls=tf.data.AUTOTUNE
+        )
+        
+        # Split into inputs and targets
+        print("Creating input-target pairs...")
+        examples_ds = windows_ds.map(
+            lambda window: (window[:-1], window[1:], tf.ones_like(window[:-1], dtype=tf.uint8)),
+            num_parallel_calls=tf.data.AUTOTUNE
+        )
+        
+        # Batch the examples
+        print(f"Batching examples with batch size {self._batch_size}...")
+        batches_ds = examples_ds.batch(
+            self._batch_size,
+            drop_remainder=True
+        )
+        
+        # Prefetch for better performance
+        print("Setting up prefetching...")
+        batches_ds = batches_ds.prefetch(tf.data.AUTOTUNE)
+        
+        # Report pipeline setup time
+        elapsed = time.time() - start_time
+        print(f"Dataset pipeline setup completed in {elapsed:.2f} seconds")
+        print("Note: Actual data loading will begin when the first batch is requested")
+        
+        return batches_ds
+    
+    def iterate_once(self, batch_size, num_steps):
+        """Iterate through the dataset once, yielding batches.
+        
+        Args:
+            batch_size: Batch size for the dataset (must match initialization)
+            num_steps: Number of steps for the dataset (must match initialization)
+            
+        Yields:
+            Tuples of (inputs, targets, weights) as JAX arrays
+        """
+        assert batch_size == self._batch_size, f"Batch size mismatch: requested {batch_size}, dataset uses {self._batch_size}"
+        assert num_steps == self._num_steps, f"Steps mismatch: requested {num_steps}, dataset uses {self._num_steps}"
+        
+        # Iterate through the TensorFlow dataset
+        start_time = time.time()
+        print(f"Beginning dataset iteration with {'unlimited' if self._max_tokens is None else self._max_tokens} max tokens")
+        
+        token_count = 0
+        batch_count = 0
+        for batch in self._tf_dataset:
+            if batch_count == 0:
+                print(f"First batch loaded after {time.time() - start_time:.2f} seconds")
+                
+            x, y, w = batch
+            
+            # Track token count and batches for reporting
+            batch_tokens = tf.reduce_sum(w).numpy()
+            token_count += batch_tokens
+            batch_count += 1
+            
+            # Print progress every 10 batches
+            if batch_count % 10 == 0:
+                elapsed = time.time() - start_time
+                print(f"Processed {batch_count} batches, {token_count} tokens so far ({token_count/elapsed:.1f} tokens/sec)")
+            
+            # Convert TensorFlow tensors to JAX arrays
+            yield jnp.array(x), jnp.array(y), jnp.array(w)
+            
+            # Track token count for max_tokens limit
+            if self._max_tokens is not None and token_count >= self._max_tokens:
+                print(f"Reached max_tokens limit ({self._max_tokens}) after {batch_count} batches")
+                break
+                
+        elapsed = time.time() - start_time
+        print(f"Dataset iteration completed: {batch_count} batches, {token_count} tokens in {elapsed:.2f} seconds")
+
+class LSTM(nnx.Module):
+    """LSTM Language Model implementation using Flax NNX."""
+    
+    def __init__(self, vocab_size, emb_size, hidden_size, num_layers, keep_prob=1.0, rngs=None):
+        """Initialize LSTM Language Model.
+        
+        Args:
+            vocab_size: Size of vocabulary
+            emb_size: Embedding dimension
+            hidden_size: Hidden dimension of LSTM
+            num_layers: Number of LSTM layers
+            keep_prob: Dropout keep probability
+            rngs: Random number generator state
+        """
+        super().__init__()
+        
+        self.vocab_size = vocab_size
+        self.emb_size = emb_size
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.keep_prob = keep_prob
+        
+        if rngs is None:
+            rngs = nnx.Rngs(0)
+        
+        # Embedding layer
+        self.embedding = nnx.Embed(
+            num_embeddings=vocab_size,
+            features=emb_size,
+            embedding_init=nnx.initializers.normal(stddev=0.1),
+            rngs=rngs
+        )
+        
+        # LSTM layers
+        self.lstm_cells = []
+        for i in range(num_layers):
+            in_features = emb_size if i == 0 else hidden_size
+            cell = nnx.OptimizedLSTMCell(
+                in_features=in_features,
+                hidden_features=hidden_size,
+                kernel_init=nnx.initializers.normal(stddev=0.1),
+                recurrent_kernel_init=nnx.initializers.normal(stddev=0.1),
+                bias_init=nnx.initializers.zeros_init(),
+                rngs=rngs
+            )
+            self.lstm_cells.append(cell)
+        
+        # Output layer
+        self.output = nnx.Linear(
+            in_features=hidden_size,
+            out_features=vocab_size,
+            kernel_init=nnx.initializers.normal(stddev=0.1),
+            bias_init=nnx.initializers.zeros_init(),
+            rngs=rngs
+        )
+
+    def initialize_carry(self, batch_size):
+        """Initialize LSTM cell states for each layer."""
+        carries = []
+        for cell in self.lstm_cells:
+            carry = cell.initialize_carry((batch_size, self.emb_size))
+            carries.append(carry)
+        return carries
+    
+    def __call__(self, inputs, carries=None, training=True):
+        """Forward pass of the LSTM Language Model.
+        
+        Args:
+            inputs: Input token ids of shape [batch_size, seq_len]
+            carries: Initial LSTM cell states for each layer
+            training: Whether to apply dropout
+        
+        Returns:
+            logits: Output logits of shape [batch_size, seq_len, vocab_size]
+            new_carries: Updated LSTM cell states for each layer
+        """
+        batch_size, seq_len = inputs.shape
+        
+        # Initialize carries if not provided
+        if carries is None:
+            carries = self.initialize_carry(batch_size)
+        
+        # Embed inputs
+        embedded = self.embedding(inputs)  # [batch_size, seq_len, emb_size]
+        
+        # Apply dropout to embeddings
+        if training and self.keep_prob < 1.0:
+            dropout = nnx.Dropout(rate=1.0-self.keep_prob, rngs=nnx.Rngs(0))
+            embedded = dropout(embedded, deterministic=not training)
+        
+        # Process inputs through LSTM layers
+        outputs = jnp.zeros((batch_size, seq_len, self.hidden_size))
+        new_carries = []
+        
+        # Process each timestep
+        for t in range(seq_len):
+            x = embedded[:, t, :]
+            h = x
+            current_carries = []
+            
+            # Process through each LSTM layer
+            for i, cell in enumerate(self.lstm_cells):
+                carry, h = cell(carries[i], h)
+                current_carries.append(carry)
+                
+                # Apply dropout between layers (but not on the output of the last layer)
+                if training and self.keep_prob < 1.0 and i < len(self.lstm_cells) - 1:
+                    dropout = nnx.Dropout(rate=1.0-self.keep_prob, rngs=nnx.Rngs(1))
+                    h = dropout(h, deterministic=not training)
+            
+            # Store output and update carries
+            outputs = outputs.at[:, t, :].set(h)
+            carries = current_carries
+        
+        # Apply output layer to get logits
+        outputs = outputs.reshape(-1, self.hidden_size)
+        logits = self.output(outputs)
+        logits = logits.reshape(batch_size, seq_len, self.vocab_size)
+        
+        new_carries = carries
+        return logits, new_carries
+
+def compute_loss(logits, targets, weights=None):
+    """Compute cross entropy loss with optional masking.
+    
+    Args:
+        logits: Model logits of shape [batch_size, seq_len, vocab_size]
+        targets: Target token ids of shape [batch_size, seq_len]
+        weights: Optional weights for masking of shape [batch_size, seq_len]
+    
+    Returns:
+        loss: Scalar loss value
+    """
+    # Reshape for computing loss
+    batch_size, seq_len = targets.shape
+    logits = logits.reshape(-1, logits.shape[-1])
+    targets = targets.reshape(-1)
+    
+    # Compute cross entropy loss
+    loss = optax.softmax_cross_entropy_with_integer_labels(logits, targets)
+    
+    # Apply weights if provided
+    if weights is not None:
+        weights = weights.reshape(-1)
+        loss = loss * weights
+        # Normalize by sum of weights
+        return jnp.sum(loss) / (jnp.sum(weights) + 1e-8)
+    
+    return jnp.mean(loss)
+
+def compute_perplexity(loss):
+    """Convert loss to perplexity."""
+    return jnp.exp(loss)
+
+def train_step(optimizer, batch):
+    """Perform a single training step.
+    
+    Args:
+        optimizer: NNX optimizer containing the model
+        batch: Batch of data containing (inputs, targets, weights)
+    
+    Returns:
+        loss: Loss value for this batch
+        grad_norm: Norm of the gradients
+        optimizer: Updated optimizer
+    """
+    inputs, targets, weights = batch
+    
+    def loss_fn(model):
+        logits, _ = model(inputs, training=True)
+        loss = compute_loss(logits, targets, weights)
+        return loss
+    
+    # Compute gradients
+    model = optimizer.model
+    loss = loss_fn(model)
+    grads = nnx.grad(loss_fn)(model)
+    
+    # Compute gradient norm
+    grads_flat = jax.tree_util.tree_leaves(grads)
+    grad_norm = jnp.sqrt(sum(jnp.sum(jnp.square(g)) for g in grads_flat))
+    
+    # Update parameters
+    optimizer.update(grads)
+    
+    return loss, grad_norm, optimizer
+
+def evaluate(model, data_iterator):
+    """Evaluate the model on the provided data.
+    
+    Args:
+        model: LSTM model
+        data_iterator: Iterator yielding evaluation batches
+    
+    Returns:
+        avg_loss: Average loss over all batches
+        perplexity: Perplexity calculated from avg_loss
+    """
+    total_loss = 0.0
+    total_weights = 0.0
+    
+    for batch in data_iterator:
+        inputs, targets, weights = batch
+        
+        # Forward pass
+        logits, _ = model(inputs, training=False)
+        
+        # Compute loss
+        loss = compute_loss(logits, targets, weights)
+        
+        # Accumulate loss weighted by batch size
+        batch_weight = jnp.sum(weights)
+        total_loss += loss * batch_weight
+        total_weights += batch_weight
+    
+    # Compute average loss and perplexity
+    if total_weights > 0:
+        avg_loss = total_loss / total_weights
+        perplexity = compute_perplexity(avg_loss)
+    else:
+        # Return default values if no valid data
+        avg_loss = jnp.array(0.0)
+        perplexity = jnp.array(1.0)
+    
+    return avg_loss, perplexity
+
+def count_parameters(model):
+    """Count the number of parameters in the model."""
+    state = nnx.state(model)
+    return sum(p.size for p in jax.tree_util.tree_leaves(state))
+
+def create_learning_curve_plot(tokens, perplexities, num_params):
+    """Create a log-log plot of the learning curve.
+    
+    Args:
+        tokens: List of token counts
+        perplexities: List of perplexity values
+        num_params: Number of model parameters
+    """
+    # Convert to numpy arrays
+    tokens = np.array(tokens)
+    perplexities = np.array(perplexities)
+    
+    # Fit power law: perplexity = a * (tokens)^b
+    log_tokens = np.log(tokens)
+    log_perplexity = np.log(perplexities)
+    
+    # Only fit if we have enough data points
+    if len(tokens) > 2:
+        # Linear fit in log-log space
+        slope, intercept, r_value, p_value, std_err = stats.linregress(log_tokens, log_perplexity)
+        
+        # Power law parameters: perplexity = A * tokens^beta
+        A = np.exp(intercept)
+        beta = slope
+        fit_perplexity = A * (tokens ** beta)
+        fit_label = f"ε(m) = {A:.1f} m^({beta:.3f})"
+    else:
+        fit_perplexity = None
+        fit_label = "Insufficient data for fit"
+    
+    # Create the figure
+    fig, ax = plt.subplots(figsize=(10, 6))
+    
+    # Plot the learning curve
+    ax.loglog(tokens, perplexities, 'o-', color='blue', label=f'{NUM_LAYERS}-Layer LSTM (actual)')
+    
+    # Plot the fit if available
+    if fit_perplexity is not None:
+        ax.loglog(tokens, fit_perplexity, '--', color='red', label=fit_label)
+    
+    # Set axis labels and title
+    ax.set_xlabel('Training Tokens (millions)')
+    ax.set_ylabel('Validation Perplexity')
+    ax.set_title(f'LSTM Language Model Learning Curve\n{num_params:,} parameters, {HIDDEN_SIZE} hidden units')
+    
+    # Convert x-axis to millions
+    ax.xaxis.set_major_formatter(ticker.FuncFormatter(lambda x, pos: f'{x/1e6:.1f}'))
+    
+    # Add grid
+    ax.grid(True, which='both', linestyle='--', alpha=0.7)
+    
+    # Add legend
+    ax.legend()
+    
+    # Generate a more descriptive filename that includes key parameters
+    output_filename = (
+        f"{RESULTS_DIR}/sgd_learning_curve_steps_{TRAIN_STEPS}_layers_{NUM_LAYERS}_"
+        f"hidden_{HIDDEN_SIZE}_emb_{EMB_SIZE}_lr_{LEARNING_RATE}_"
+        f"keep_{KEEP_PROB}_maxtokens_{MAX_TOKENS}.pdf"
+    )
+    
+    # Save figure
+    plt.tight_layout()
+    plt.savefig(output_filename)
+    
+    print(f"\nLearning curve plot saved as {output_filename}")
+
+def run_lstm_with_optimizer(model, optax_optimizer, train_dataset, valid_dataset, train_steps, store_sigmoid_sum=False):
+    """
+    Train an LSTM model using the specified optimizer.
+    
+    Args:
+        model: LSTM model instance
+        optax_optimizer: Optax optimizer
+        train_dataset: Training dataset
+        valid_dataset: Validation dataset
+        train_steps: Number of training steps
+        store_sigmoid_sum: Whether to store sigmoid_sum (for DANA optimizer)
+        
+    Returns:
+        loss_times: Steps at which metrics were recorded
+        metrics_history: Dictionary of metrics
+        num_params: Number of model parameters
+    """
+    # Create NNX optimizer
+    optimizer = nnx.Optimizer(model, optax_optimizer)
+    
+    # Prepare for training
+    metrics_history = {
+        'step': [],
+        'train_loss': [],
+        'train_perplexity': [],
+        'train_grad_norm': [],
+        'val_loss': [],
+        'val_perplexity': []
+    }
+    
+    # Add sigmoid_sum if using DANA
+    if store_sigmoid_sum:
+        metrics_history['sigmoid_sum'] = []
+    
+    # Training loop
+    print(f"Starting training for {train_steps} steps")
+    step = 0
+    train_iterator = train_dataset.iterate_once(BATCH_SIZE, NUM_STEPS)
+    
+    start_time = time.time()
+    
+    # Create a tqdm progress bar
+    with tqdm(total=train_steps, initial=step, desc="Training", dynamic_ncols=True, file=sys.stderr) as pbar:
+        for batch in train_iterator:
+            if step >= train_steps:
+                break
+            
+            # Perform training step
+            loss, grad_norm, optimizer = train_step(optimizer, batch)
+            
+            # Update the progress bar description with current loss
+            pbar.set_postfix({"loss": f"{loss:.4f}", "perplexity": f"{compute_perplexity(loss):.2f}"})
+            
+            # Log metrics at specified intervals
+            if step in LOG_STEPS:
+                perplexity = compute_perplexity(loss)
+                
+                metrics_history['step'].append(step)
+                metrics_history['train_loss'].append(loss)
+                metrics_history['train_perplexity'].append(perplexity)
+                metrics_history['train_grad_norm'].append(grad_norm)
+                
+                # Store sigmoid_sum if requested (just use a constant value for compatibility)
+                if store_sigmoid_sum:
+                    sigmoid_sum = 0.0
+                    metrics_history['sigmoid_sum'].append(sigmoid_sum)
+                
+                # Evaluate on validation set
+                valid_iterator = valid_dataset.iterate_once(BATCH_SIZE, NUM_STEPS)
+                val_loss, val_perplexity = evaluate(optimizer.model, valid_iterator)
+                
+                metrics_history['val_loss'].append(val_loss)
+                metrics_history['val_perplexity'].append(val_perplexity)
+                
+                # Print metrics (outside of the progress bar)
+                elapsed = time.time() - start_time
+                log_print(f"Step: {step}/{train_steps} ({100.0 * step / train_steps:.1f}%) - Time: {elapsed:.2f}s")
+                log_print(f"  Train Loss: {loss:.4f}, Perplexity: {perplexity:.2f}, Grad Norm: {grad_norm:.2f}")
+                if store_sigmoid_sum:
+                    log_print(f"  Sigmoid Sum: {sigmoid_sum:.4f}")
+                log_print(f"  Valid Loss: {val_loss:.4f}, Perplexity: {val_perplexity:.2f}")
+            
+            # Update the progress bar
+            pbar.update(1)
+            step += 1
+    
+    # Final evaluation
+    valid_iterator = valid_dataset.iterate_once(BATCH_SIZE, NUM_STEPS)
+    final_loss, final_perplexity = evaluate(optimizer.model, valid_iterator)
+    
+    print("\nTraining completed!")
+    print(f"Final validation loss: {final_loss:.4f}, perplexity: {final_perplexity:.2f}")
+    
+    # Count model parameters
+    num_params = count_parameters(model)
+    print(f"Model parameters: {num_params}")
+    
+    return LOG_STEPS, metrics_history, num_params
+
+def create_comparison_plot(sgd_metrics, dana_metrics, loss_times, num_params):
+    """Create a comparison plot between SGD and DANA optimizers.
+    
+    Args:
+        sgd_metrics: Metrics history from SGD training
+        dana_metrics: Metrics history from DANA training 
+        loss_times: Steps at which metrics were recorded
+        num_params: Number of model parameters
+    """
+    # Create the figure
+    fig, ax1 = plt.subplots(figsize=(10, 6))
+    ax1.set_title('Loss Comparison')
+    
+    # Determine the minimum length of data to plot
+    min_length = min(len(sgd_metrics['train_loss']), 
+                    len(dana_metrics['train_loss']) if dana_metrics else float('inf'))
+    
+    # Create a second y-axis for sigmoid-sum if available
+    if dana_metrics and 'sigmoid_sum' in dana_metrics:
+        ax1_right = ax1.twinx()
+        ax1_right.set_yscale('log')
+        ax1_right.set_ylabel('Sigmoid Sum', color='grey')
+    
+    # Skip step 0 and ensure we don't go beyond min_length
+    skip = 1  # Skip the first entry (step 0)
+    tokens = np.array(loss_times[skip:min_length]) * BATCH_SIZE * NUM_STEPS
+    
+    # Plot SGD results
+    for dataset in ('train', 'val'):
+        data = sgd_metrics[f'{dataset}_loss'][skip:min_length]
+        ax1.loglog(tokens, data, label=f'SGD {dataset}_loss')
+    
+    # Plot DANA results if available
+    if dana_metrics:
+        for dataset in ('train', 'val'):
+            data = dana_metrics[f'{dataset}_loss'][skip:min_length]
+            ax1.loglog(tokens, data, label=f'DANA {dataset}_loss')
+        
+        # Plot sigmoid sum if available
+        if 'sigmoid_sum' in dana_metrics:
+            sigmoid_data = dana_metrics['sigmoid_sum'][skip:min_length]
+            if np.any(sigmoid_data):  # Only plot if values are non-zero
+                ax1_right.loglog(tokens, sigmoid_data, color='grey', linestyle='--', label='Sigmoid Sum')
+                ax1_right.tick_params(axis='y', labelcolor='grey')
+    
+    # Add horizontal and vertical grid lines
+    ax1.grid(True, which='both', axis='both', linestyle='--', alpha=0.7)
+    
+    # Set more y-axis ticks
+    ax1.yaxis.set_major_formatter(ticker.FormatStrFormatter('%.3g'))
+    
+    # Set axis labels
+    ax1.set_xlabel('Training Tokens')
+    ax1.set_ylabel('Loss')
+    
+    # Add legend
+    ax1.legend(loc='upper left')
+    if dana_metrics and 'sigmoid_sum' in dana_metrics:
+        ax1_right.legend(loc='lower left')
+    
+    # Add title
+    fig.suptitle(f"LSTM Language Model Training ({num_params:,} parameters)")
+    
+    # Generate a more descriptive filename that includes key parameters
+    optimizer_str = "sgd_vs_dana" if dana_metrics else "sgd"
+    output_filename = (
+        f"{RESULTS_DIR}/comparison_{optimizer_str}_steps_{TRAIN_STEPS}_layers_{NUM_LAYERS}_"
+        f"hidden_{HIDDEN_SIZE}_emb_{EMB_SIZE}_lr_{LEARNING_RATE}_"
+        f"keep_{KEEP_PROB}_maxtokens_{MAX_TOKENS}"
+    )
+    
+    # Add DANA parameters if applicable
+    if dana_metrics:
+        output_filename += (f"_g3_iv={DANA_G3_IV}_sv={DANA_G3_SV}_"
+                          f"p={DANA_G3_P}_ts={DANA_G3_TS}_delta={DANA_DELTA}")
+    
+    # Add file extension
+    output_filename += ".pdf"
+    
+    # Save figure
+    plt.tight_layout()
+    plt.savefig(output_filename)
+    
+    print(f"\nComparison plot saved to {output_filename}")
+
+def main():
+    # Initialize random seed for reproducibility
+    rng = jrandom.PRNGKey(42)
+    
+    # Load vocabulary (limit to top 10k words)
+    print(f"Loading vocabulary from {VOCAB_FILE}")
+    start_time = time.time()
+    vocab = Vocabulary.from_file(VOCAB_FILE, max_vocab_size=VOCAB_SIZE)
+    print(f"Vocabulary size: {vocab.num_tokens}, loaded in {time.time() - start_time:.2f} seconds")
+    
+    # Create dataset using all shuffled files for training
+    train_pattern = f"{DATA_PATH}/*.en.shuffled"
+    train_files = glob.glob(train_pattern)
+    print(f"Found {len(train_files)} training files")
+    
+    # Get validation files (using *.en files)
+    valid_pattern = f"{DATA_PATH}/*.en"
+    valid_files = glob.glob(valid_pattern)
+    print(f"Found {len(valid_files)} validation files")
+    
+    # Use all shuffled files for training and one .en file for validation
+    if len(valid_files) > 0:
+        valid_pattern = valid_files[-1]  # Use last .en file for validation
+    else:
+        print("Warning: No .en files found for validation, using training file")
+        valid_pattern = train_files[-1]
+    
+    print(f"Using pattern {train_pattern} for training")
+    print(f"Using {valid_pattern} for validation")
+    
+    # Create datasets - using either the original Dataset implementation or the new TFDataset
+    use_tf_dataset = True  # Set to True to use TensorFlow-based dataset
+    
+    if use_tf_dataset:
+        print("Using TensorFlow-based dataset implementation")
+        print(f"Creating validation dataset (max_tokens={MAX_VAL_TOKENS})...")
+        valid_dataset = TFDataset(vocab, valid_pattern, BATCH_SIZE, NUM_STEPS, deterministic=True, max_tokens=MAX_VAL_TOKENS, is_validation=True)
+        
+        print(f"Creating training dataset (max_tokens={MAX_TOKENS})...")
+        train_dataset = TFDataset(vocab, train_pattern, BATCH_SIZE, NUM_STEPS, deterministic=False, max_tokens=MAX_TOKENS)
+    else:
+        print("Using original dataset implementation")
+        train_dataset = Dataset(vocab, train_pattern, max_tokens=MAX_TOKENS)
+        valid_dataset = Dataset(vocab, valid_pattern, deterministic=True, max_tokens=MAX_VAL_TOKENS)
+    
+    # Create a config dictionary for matching with saved runs
+    sgd_config = {
+        "optimizer": "sgd",
+        "batch_size": BATCH_SIZE,
+        "num_steps": NUM_STEPS,
+        "train_steps": TRAIN_STEPS,
+        "vocab_size": VOCAB_SIZE,
+        "emb_size": EMB_SIZE,
+        "hidden_size": HIDDEN_SIZE,
+        "num_layers": NUM_LAYERS,
+        "learning_rate": LEARNING_RATE,
+        "max_grad_norm": MAX_GRAD_NORM,
+        "keep_prob": KEEP_PROB,
+        "max_tokens": MAX_TOKENS,
+    }
+    
+    # Generate a more comprehensive filename that includes key parameters
+    sgd_metrics_filename = (
+        f"{RESULTS_DIR}/sgd_metrics_history_steps_{TRAIN_STEPS}_layers_{NUM_LAYERS}_"
+        f"hidden_{HIDDEN_SIZE}_emb_{EMB_SIZE}_lr_{LEARNING_RATE}_maxgrad_{MAX_GRAD_NORM}_"
+        f"keep_{KEEP_PROB}_maxtokens_{MAX_TOKENS}.pkl"
+    )
+    
+    # Try to load saved SGD results first
+    try:
+        print(f"Attempting to load saved SGD metrics from {sgd_metrics_filename}")
+        with open(sgd_metrics_filename, "rb") as f:
+            saved_config, sgd_loss_times, sgd_metrics_history, num_params = pickle.load(f)
+            
+        # Verify that the saved configuration matches the current one
+        config_match = True
+        for key, value in sgd_config.items():
+            if key not in saved_config or saved_config[key] != value:
+                config_match = False
+                break
+        
+        if config_match:
+            print("Successfully loaded SGD metrics from file with matching configuration")
+        else:
+            print("Found saved SGD metrics but configuration doesn't match. Running training again.")
+            raise ValueError("Configuration mismatch")
+            
+    except (FileNotFoundError, IOError, ValueError):
+        # If the file doesn't exist or config doesn't match, run SGD training
+        print("Running SGD training")
+        
+        # Initialize model
+        rng, init_rng = jrandom.split(rng)
+        rngs = nnx.Rngs(init_rng)
+        
+        sgd_model = LSTM(
+            vocab_size=vocab.num_tokens,
+            emb_size=EMB_SIZE,
+            hidden_size=HIDDEN_SIZE,
+            num_layers=NUM_LAYERS,
+            keep_prob=KEEP_PROB,
+            rngs=rngs
+        )
+        
+        # Initialize model parameters
+        dummy_input = jnp.zeros((BATCH_SIZE, NUM_STEPS), dtype=jnp.int32)
+        sgd_model(dummy_input)
+        
+        # Initialize SGD optimizer with gradient clipping
+        sgd_optax = optax.chain(
+            optax.clip_by_global_norm(MAX_GRAD_NORM),
+            optax.sgd(learning_rate=LEARNING_RATE)
+        )
+        
+        # Run SGD training
+        sgd_loss_times, sgd_metrics_history, num_params = run_lstm_with_optimizer(
+            sgd_model,
+            sgd_optax,
+            train_dataset,
+            valid_dataset,
+            TRAIN_STEPS,
+            store_sigmoid_sum=False
+        )
+        
+        # Save SGD results to file, including the configuration
+        with open(sgd_metrics_filename, 'wb') as f:
+            pickle.dump((sgd_config, sgd_loss_times, sgd_metrics_history, num_params), f)
+        print(f"SGD metrics saved to {sgd_metrics_filename}")
+    
+    # Create learning curve plot for SGD
+    tokens_list = []
+    perplexity_list = []
+    for i, step in enumerate(sgd_metrics_history['step']):
+        if step > 0:  # Skip step 0
+            tokens = step * BATCH_SIZE * NUM_STEPS
+            perplexity = sgd_metrics_history['val_perplexity'][i]
+            tokens_list.append(tokens)
+            perplexity_list.append(perplexity)
+    
+    # Create SGD learning curve plot
+    create_learning_curve_plot(tokens_list, perplexity_list, num_params)
+    
+    # Run DANA if specified
+    dana_metrics_history = None
+    if OPTIMIZER == "dana":
+        # Create a config dictionary for matching with saved runs
+        dana_config = {
+            "optimizer": "dana",
+            "batch_size": BATCH_SIZE,
+            "num_steps": NUM_STEPS,
+            "train_steps": TRAIN_STEPS,
+            "vocab_size": VOCAB_SIZE,
+            "emb_size": EMB_SIZE,
+            "hidden_size": HIDDEN_SIZE,
+            "num_layers": NUM_LAYERS,
+            "learning_rate": LEARNING_RATE,
+            "max_grad_norm": MAX_GRAD_NORM,
+            "keep_prob": KEEP_PROB,
+            "max_tokens": MAX_TOKENS,
+            # DANA-specific parameters
+            "population_trace": POPULATION_TRACE,
+            "dana_g3_iv": DANA_G3_IV,
+            "dana_g3_sv": DANA_G3_SV,
+            "dana_g3_p": DANA_G3_P,
+            "dana_g3_ts": DANA_G3_TS,
+            "dana_delta": DANA_DELTA,
+        }
+        
+        # Generate a more comprehensive filename that includes key parameters
+        dana_metrics_filename = (
+            f"{RESULTS_DIR}/dana_metrics_history_steps_{TRAIN_STEPS}_layers_{NUM_LAYERS}_"
+            f"hidden_{HIDDEN_SIZE}_emb_{EMB_SIZE}_lr_{LEARNING_RATE}_maxgrad_{MAX_GRAD_NORM}_"
+            f"keep_{KEEP_PROB}_maxtokens_{MAX_TOKENS}_g3_iv={DANA_G3_IV}_sv={DANA_G3_SV}_"
+            f"p={DANA_G3_P}_ts={DANA_G3_TS}_delta={DANA_DELTA}.pkl"
+        )
+        
+        # Try to load saved DANA results first
+        try:
+            print(f"Attempting to load saved DANA metrics from {dana_metrics_filename}")
+            with open(dana_metrics_filename, "rb") as f:
+                saved_config, dana_loss_times, dana_metrics_history, _ = pickle.load(f)
+                
+            # Verify that the saved configuration matches the current one
+            config_match = True
+            for key, value in dana_config.items():
+                if key not in saved_config or saved_config[key] != value:
+                    config_match = False
+                    break
+            
+            if config_match:
+                print("Successfully loaded DANA metrics from file with matching configuration")
+            else:
+                print("Found saved DANA metrics but configuration doesn't match. Running training again.")
+                raise ValueError("Configuration mismatch")
+                
+        except (FileNotFoundError, IOError, ValueError):
+            # If the file doesn't exist or config doesn't match, run DANA training
+            print("Running DANA training")
+            
+            # Initialize model with same seed
+            rng, init_rng = jrandom.split(jrandom.PRNGKey(42))
+            rngs = nnx.Rngs(init_rng)
+            
+            dana_model = LSTM(
+                vocab_size=vocab.num_tokens,
+                emb_size=EMB_SIZE,
+                hidden_size=HIDDEN_SIZE,
+                num_layers=NUM_LAYERS,
+                keep_prob=KEEP_PROB,
+                rngs=rngs
+            )
+            
+            # Initialize model parameters
+            dummy_input = jnp.zeros((BATCH_SIZE, NUM_STEPS), dtype=jnp.int32)
+            dana_model(dummy_input)
+            
+            # Configure DANA optimizer
+            g1 = optimizers.powerlaw_schedule(1.0, 0.0, 0.0, 1)
+            g2 = optimizers.powerlaw_schedule(LEARNING_RATE, 0.0, 0.0, 1)
+            Delta = optimizers.powerlaw_schedule(1.0, 0.0, -1.0, DANA_DELTA)
+            g3 = optimizers.powerlaw_schedule(DANA_G3_IV, DANA_G3_SV, DANA_G3_P, DANA_G3_TS)
+            
+            # Run DANA Classic
+            dana_classic = optimizers.dana_optimizer(g1=g1, g2=g2, g3=g3, Delta=Delta)
+
+            dana_optax = optax.chain(
+                optax.clip_by_global_norm(MAX_GRAD_NORM),
+                dana_classic
+            )
+            
+            # Run DANA training
+            dana_loss_times, dana_metrics_history, _ = run_lstm_with_optimizer(
+                dana_model,
+                dana_optax,
+                train_dataset,
+                valid_dataset,
+                TRAIN_STEPS,
+                store_sigmoid_sum=True
+            )
+            
+            # Save DANA results to file, including the configuration
+            with open(dana_metrics_filename, 'wb') as f:
+                pickle.dump((dana_config, dana_loss_times, dana_metrics_history, num_params), f)
+            print(f"DANA metrics saved to {dana_metrics_filename}")
+        
+        # Create comparison plot
+        create_comparison_plot(sgd_metrics_history, dana_metrics_history, sgd_loss_times, num_params)
+
+if __name__ == "__main__":
+    main()

--- a/dana-nonquadratic-tests/lstm-1b/plot_all_dana_curves.py
+++ b/dana-nonquadratic-tests/lstm-1b/plot_all_dana_curves.py
@@ -1,0 +1,196 @@
+import os
+import glob
+import pickle
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import scipy.stats as stats
+
+# Configuration
+RESULTS_DIR = "results"
+BATCH_SIZE = 128
+NUM_STEPS = 20
+TRAIN_STEPS = 10000
+NUM_LAYERS = 2
+HIDDEN_SIZE = 64
+EMB_SIZE = 32
+LEARNING_RATE = 0.1
+MAX_GRAD_NORM = 10.0
+KEEP_PROB = 0.9
+MAX_TOKENS = None
+
+def fit_power_law(tokens, values):
+    """Fit a power law to the data.
+    
+    Args:
+        tokens: Array of token counts
+        values: Array of values to fit
+        
+    Returns:
+        A: Amplitude of the power law
+        beta: Exponent of the power law
+        fit_values: Fitted values
+        r_value: R-squared value of the fit
+    """
+    # Convert to numpy arrays
+    tokens = np.array(tokens)
+    values = np.array(values)
+    
+    # Fit power law: value = A * (tokens)^beta
+    log_tokens = np.log(tokens)
+    log_values = np.log(values)
+    
+    # Linear fit in log-log space
+    slope, intercept, r_value, p_value, std_err = stats.linregress(log_tokens, log_values)
+    
+    # Power law parameters: value = A * tokens^beta
+    A = np.exp(intercept)
+    beta = slope
+    fit_values = A * (tokens ** beta)
+    
+    return A, beta, fit_values, r_value
+
+def plot_all_curves():
+    """Create separate plots for training and validation perplexity curves with power law fits."""
+    # Find all DANA metrics files with 100000 steps
+    pattern = f"{RESULTS_DIR}/dana_metrics_history_steps_{TRAIN_STEPS}_layers_{NUM_LAYERS}_" \
+             f"hidden_{HIDDEN_SIZE}_emb_{EMB_SIZE}_lr_{LEARNING_RATE}_maxgrad_{MAX_GRAD_NORM}_" \
+             f"keep_{KEEP_PROB}_maxtokens_{MAX_TOKENS}_g3_iv=0.5_sv=0.0_p=*.pkl"
+    
+    dana_files = glob.glob(pattern)
+    
+    if not dana_files:
+        print(f"No DANA metrics files found matching pattern: {pattern}")
+        return
+    
+    # Find SGD metrics file
+    sgd_file = f"{RESULTS_DIR}/sgd_metrics_history_steps_{TRAIN_STEPS}_layers_{NUM_LAYERS}_" \
+               f"hidden_{HIDDEN_SIZE}_emb_{EMB_SIZE}_lr_{LEARNING_RATE}_maxgrad_{MAX_GRAD_NORM}_" \
+               f"keep_{KEEP_PROB}_maxtokens_{MAX_TOKENS}.pkl"
+    
+    if not os.path.exists(sgd_file):
+        print(f"SGD metrics file not found: {sgd_file}")
+        return
+    
+    # Extract p values and sort files
+    dana_files_with_p = [(f, float(f.split('p=')[1].split('_')[0])) for f in dana_files]
+    dana_files_with_p.sort(key=lambda x: x[1])  # Sort by p value
+    dana_files = [f[0] for f in dana_files_with_p]
+    
+    # Colors for different curves
+    dana_colors = plt.cm.viridis(np.linspace(0, 1, len(dana_files)))
+    sgd_color = 'red'  # Use red for SGD
+    
+    # Create two figures - one for training and one for validation
+    fig_train, ax_train = plt.subplots(figsize=(12, 8))
+    fig_val, ax_val = plt.subplots(figsize=(12, 8))
+    
+    # Plot SGD curve first
+    print(f"Loading SGD metrics from {sgd_file}")
+    with open(sgd_file, "rb") as f:
+        saved_config, loss_times, metrics_history, num_params = pickle.load(f)
+    
+    # Skip step 0 and convert to tokens
+    skip = 1
+    data_length = len(metrics_history['train_perplexity'])
+    tokens = np.array(loss_times[skip:skip+data_length]) * BATCH_SIZE * NUM_STEPS
+    
+    # Calculate the midpoint for using only the second half of the data
+    midpoint = len(tokens) // 2
+    
+    # Plot SGD training and validation curves
+    for dataset, ax in [('train_perplexity', ax_train), ('val_perplexity', ax_val)]:
+        data = np.array(metrics_history[dataset])
+        label_prefix = 'Train' if dataset == 'train_perplexity' else 'Val'
+        
+        # Plot the actual data
+        ax.loglog(tokens, data, 'o-', color=sgd_color, 
+                 label=f'SGD', 
+                 alpha=0.7, markersize=4)
+        
+        # Fit power law using only the second half of the data
+        if len(tokens[midpoint:]) > 2:  # Need at least 3 points for a fit
+            A, beta, fit_values, r_value = fit_power_law(tokens[midpoint:], data[midpoint:])
+            
+            # Plot the fit
+            ax.loglog(tokens[midpoint:], fit_values, '--', color=sgd_color, 
+                     label=f'SGD fit: {A:.2f} * m^({beta:.3f}), R²={r_value**2:.3f}', 
+                     alpha=1.0, linewidth=2)
+    
+    # Plot each DANA curve
+    for i, dana_file in enumerate(dana_files):
+        # Extract p value from filename
+        p_value = float(dana_file.split('p=')[1].split('_')[0])
+        
+        # Load the metrics
+        print(f"Loading DANA metrics from {dana_file}")
+        with open(dana_file, "rb") as f:
+            saved_config, loss_times, metrics_history, num_params = pickle.load(f)
+        
+        # Skip step 0 and convert to tokens
+        skip = 1
+        data_length = len(metrics_history['train_perplexity'])
+        tokens = np.array(loss_times[skip:skip+data_length]) * BATCH_SIZE * NUM_STEPS
+        
+        # Calculate the midpoint for using only the second half of the data
+        midpoint = len(tokens) // 2
+        
+        # Plot training and validation curves
+        for dataset, ax in [('train_perplexity', ax_train), ('val_perplexity', ax_val)]:
+            data = np.array(metrics_history[dataset])
+            color = dana_colors[i]
+            
+            # Plot the actual data
+            ax.loglog(tokens, data, 'o-', color=color, 
+                     label=f'DANA p={p_value:.2f}', 
+                     alpha=0.7, markersize=4)
+            
+            # Fit power law using only the second half of the data
+            if len(tokens[midpoint:]) > 2:  # Need at least 3 points for a fit
+                A, beta, fit_values, r_value = fit_power_law(tokens[midpoint:], data[midpoint:])
+                
+                # Plot the fit
+                ax.loglog(tokens[midpoint:], fit_values, '--', color=color, 
+                         label=f'DANA p={p_value:.2f} fit: {A:.2f} * m^({beta:.3f}), R²={r_value**2:.3f}', 
+                         alpha=1.0, linewidth=2)
+    
+    # Configure both plots
+    for ax, title in [(ax_train, "Training"), (ax_val, "Validation")]:
+        # Add horizontal and vertical grid lines
+        ax.grid(True, which='both', axis='both', linestyle='--', alpha=0.7)
+        
+        # Set more y-axis ticks
+        ax.yaxis.set_major_formatter(ticker.FormatStrFormatter('%.3g'))
+        
+        # Set axis labels
+        ax.set_xlabel('Training Tokens (millions)')
+        ax.set_ylabel('Perplexity')
+        
+        # Convert x-axis to millions
+        ax.xaxis.set_major_formatter(ticker.FuncFormatter(lambda x, pos: f'{x/1e6:.1f}'))
+        
+        # Add legend with smaller font
+        ax.legend(loc='center left', bbox_to_anchor=(1, 0.5), ncol=1, fontsize='small')
+        
+        # Add title
+        fig = ax.figure
+        fig.suptitle(f"DANA vs SGD {title} Perplexity Curves ({num_params:,} parameters)\n" + 
+                     f"2-layer LSTM (4-layer network), {HIDDEN_SIZE} hidden, {EMB_SIZE} embedding",
+                     y=0.95)
+        
+        # Adjust layout to prevent legend cutoff
+        fig.subplots_adjust(right=0.85)
+    
+    # Generate output filenames
+    output_filename_train = f"{RESULTS_DIR}/all_curves_train_perplexity_fits_steps_{TRAIN_STEPS}_hidden_{HIDDEN_SIZE}_emb_{EMB_SIZE}.pdf"
+    output_filename_val = f"{RESULTS_DIR}/all_curves_val_perplexity_fits_steps_{TRAIN_STEPS}_hidden_{HIDDEN_SIZE}_emb_{EMB_SIZE}.pdf"
+    
+    # Save the plots
+    fig_train.savefig(output_filename_train, bbox_inches='tight')
+    fig_val.savefig(output_filename_val, bbox_inches='tight')
+    
+    print(f"\nTraining perplexity fits plot saved to {output_filename_train}")
+    print(f"Validation perplexity fits plot saved to {output_filename_val}")
+
+if __name__ == "__main__":
+    plot_all_curves() 

--- a/dana-nonquadratic-tests/lstm-1b/run_dana_experiments.sh
+++ b/dana-nonquadratic-tests/lstm-1b/run_dana_experiments.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Script to run LSTM model with different DANA g3_p parameter values
+# This script will run the model with g3_p values: -0.5, -0.4, -0.6, -0.45, -0.55
+# Note: With max_tokens=0 (full dataset), data loading may take 5-10 minutes before
+#       training begins. The added debug information will show progress.
+
+# Create a directory for logs if it doesn't exist
+mkdir -p logs
+
+# Array of g3_p values to test
+g3_p_values=(-0.5 -0.4 -0.6 -0.45 -0.55)  
+
+# Run the model for each g3_p value
+for p in "${g3_p_values[@]}"; do
+    echo "Running model with DANA g3_p = $p"
+    logfile="logs/dana_g3_p_${p}.log"
+    
+    # Clear previous log file if it exists
+    > "$logfile"
+    
+    echo "=== Starting run with g3_p = $p at $(date) ===" | tee -a "$logfile"
+    
+    # Run with max_tokens=0 (full dataset) but fewer training steps
+    # The added debug output will show progress during data loading
+    python flax-billion-word-lstm.py --train_steps=10000 --max_tokens=0 --dana_g3_p=$p --optimizer=dana | tee -a "$logfile"
+    
+    # Check if the command was successful
+    if [ $? -eq 0 ]; then
+        echo "Successfully completed run with g3_p = $p" | tee -a "$logfile"
+    else
+        echo "Error running model with g3_p = $p" | tee -a "$logfile"
+    fi
+    
+    echo "=== Finished run with g3_p = $p at $(date) ===" | tee -a "$logfile"
+    echo "----------------------------------------"
+done
+
+echo "All experiments completed!" 


### PR DESCRIPTION
… Word dataset.  Also, this adds the ResNet CIFAR-5m experiment.

This commit introduces several new Python scripts for running DANA experiments on an LSTM model trained on the Billion Word dataset. Key additions include `flax-billion-word-lstm.py` for model training, `run_dana_experiments.sh` for executing experiments with varying DANA parameters, and plotting scripts for visualizing results. Additionally, README files have been added to provide context and instructions for the experiments. The implementation aims to facilitate comparisons between DANA and traditional SGD optimizers in language modeling tasks.

In parallel, we added the same for the CIFAR-5m ResNet experiments.