### PR TITLE
Refactor risk calculations in ode.py to clarify output terminology

### DIFF
--- a/optimizers.py
+++ b/optimizers.py
@@ -15,7 +15,7 @@ def powerlaw_schedule(
     init_value: chex.Scalar,
     saturation_value: chex.Scalar,
     power: chex.Scalar,
-    time_scale: int,
+    time_scale: chex.Scalar,
 ) -> base.Schedule:
   """Constructs power-law schedule.
 


### PR DESCRIPTION
This commit updates the `ode_resolvent_log_implicit` function to reflect that the minibatch loss is 1/batch and renames exact odes to reflect the actual stochastic algorithm and not coin flip algorithm.