### PR TITLE
Add adaptive options to ODEs

### DIFF
--- a/power_law_rf/ode.py
+++ b/power_law_rf/ode.py
@@ -1,6 +1,6 @@
 import jax
 import jax.numpy as jnp
-from typing import NamedTuple, Callable, Union
+from typing import NamedTuple, Callable, Union, Optional, Literal
 
 
 class ODEInputs(NamedTuple):
@@ -25,10 +25,13 @@ def ode_resolvent_log_implicit(
     D: int,
     t_max: float,
     dt: float,
-    approximate = False,
+    approximate: bool = False,
+    adaptive: Optional[Literal['adam', 'rmsprop_dana']] = None,
 ):
     """Generate the theoretical solution to momentum.
-    Outputs TWICE the risk.
+    Outputs TWICE the risk. Full ODE does NOT use coin-flip momentum.
+    Approximate ODE for non-coin-flip and coin-flip are the same after dropping higher-order terms.
+    Assumes the loss is AVERAGED over the batch, not summed.
 
     Parameters
     ----------
@@ -59,6 +62,13 @@ def ode_resolvent_log_implicit(
         The number of epochs
     dt : float
         time step used in Euler
+    approximate : bool
+        Whether to use the approximate ODE (drops higher order terms)
+    adaptive : Optional[Literal['adam', 'rmsprop_dana']]
+        Type of adaptive optimizer normalization:
+        - None: no normalization
+        - 'adam': normalize g3 terms (momentum entering parameters)
+        - 'rmsprop_dana': normalize g1 terms (gradients entering momentum)
 
     Returns
     -------
@@ -67,13 +77,21 @@ def ode_resolvent_log_implicit(
     twice_risks: numpy.array(float)
         twice the values of the risk, as used in the paper.
     """
-    g1, g2, g3, delta = opt_hparams.g1, opt_hparams.g2, opt_hparams.g3, opt_hparams.delta
+    g1_fn, g2_fn, g3_fn, delta_fn = opt_hparams.g1, opt_hparams.g2, opt_hparams.g3, opt_hparams.delta
     eigs_K = inputs.eigs_K
     rho_init, chi_init, sigma_init = inputs.rho_init, inputs.chi_init, inputs.sigma_init
     twice_risk_infinity = 2.0*inputs.risk_infinity
     times = jnp.arange(0, jnp.log(t_max), step=dt, dtype=jnp.float32)
     risk_init = twice_risk_infinity + jnp.sum(inputs.eigs_K * inputs.rho_init)
 
+    def get_normalization_factors(grad_norm):
+        """Compute normalization factors based on adaptive optimizer type."""
+        if adaptive == 'adam':
+            return 1.0, grad_norm
+        elif adaptive == 'rmsprop_dana':
+            return grad_norm, 1.0
+        else:
+            return 1.0, 1.0
 
     def inverse_3x3(omega):
         # Extract matrix elements
@@ -84,9 +102,6 @@ def ode_resolvent_log_implicit(
         # Calculate determinant
         det = (a11*a22*a33 + a12*a23*a31 + a13*a21*a32
                - a13*a22*a31 - a11*a23*a32 - a12*a21*a33)
-
-        #if abs(det) < 1e-10:
-        #    raise ValueError("Matrix is singular or nearly singular")
 
         # Calculate each element of inverse matrix
         inv = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
@@ -105,68 +120,110 @@ def ode_resolvent_log_implicit(
 
         return jnp.array(inv)
 
-    def omega_full(time_plus):
-        omega_11 = -2.0 * ( g2(time_plus) + g1(time_plus) * g3(time_plus) ) * eigs_K + ( batch * (batch + 1.0) ) / ( batch**2 ) * ( g2(time_plus)**2 + 2.0 * g1(time_plus) * g3(time_plus) * g2(time_plus) + g1(time_plus)**2 * g3(time_plus)**2 ) * eigs_K**2
-        omega_12 = g3(time_plus)**2 * (1.0 - delta(time_plus))**2 * jnp.ones_like(eigs_K)
-        omega_13 = -2.0 * g3(time_plus) * (1.0 - delta(time_plus)) + 2.0 * (g2(time_plus) * g3(time_plus) + g3(time_plus)**2 * g1(time_plus)) * (1.0 - delta(time_plus) ) *  eigs_K #(-1.0 + g2(time_plus) * batch * eigs_K)
+    def omega_full(time_plus, grad_norm):
+        g1_norm, g3_norm = get_normalization_factors(grad_norm)
+        
+        # Normalize hyperparameters to apply adaptivity
+        g1 = g1_fn(time_plus) / g1_norm
+        g2 = g2_fn(time_plus)
+        g3 = g3_fn(time_plus) / g3_norm
+        delta = delta_fn(time_plus)
+        
+        # Row 1: Evolution of rho
+        omega_11 = -2.0 * (g2 + g1 * g3) * eigs_K + \
+                   ((batch + 1.0) / batch) * (g2**2 + 2.0 * g1 * g3 * g2 + g1**2 * g3**2) * eigs_K**2
+        omega_12 = g3**2 * (1.0 - delta)**2 * jnp.ones_like(eigs_K)
+        omega_13 = -2.0 * g3 * (1.0 - delta) + \
+                   2.0 * (g2 * g3 + g3**2 * g1) * (1.0 - delta) * eigs_K
         omega_1 = jnp.array([omega_11, omega_12, omega_13])
 
-        omega_21 = ( batch * (batch + 1.0) ) / (batch**2) * g1(time_plus)**2 * eigs_K**2
-        omega_22 = (-2.0 * delta(time_plus) + delta(time_plus)**2) * jnp.ones_like(eigs_K)
-        omega_23 = 2.0 * g1(time_plus) * eigs_K * (1.0 - delta(time_plus))
+        # Row 2: Evolution of sigma
+        omega_21 = ((batch + 1.0) / batch) * g1**2 * eigs_K**2
+        omega_22 = (-2.0 * delta + delta**2) * jnp.ones_like(eigs_K)
+        omega_23 = 2.0 * g1 * eigs_K * (1.0 - delta)
         omega_2 = jnp.array([omega_21, omega_22, omega_23])
 
-        omega_31 = g1(time_plus) * eigs_K - ( batch * (batch + 1.0) ) / ( batch**2 ) * eigs_K**2 * ( g1(time_plus) * g2(time_plus) + g1(time_plus)**2 * g3(time_plus) )
-        omega_32 = (-g3(time_plus) + g3(time_plus) * delta(time_plus) * (2.0 - delta(time_plus)) ) * jnp.ones_like(eigs_K)
-        omega_33 = -delta(time_plus) - ( g2(time_plus) - g2(time_plus) * delta(time_plus) + 2.0 * ( 1.0 - delta(time_plus) )* g1(time_plus) * g3(time_plus) ) * eigs_K
+        # Row 3: Evolution of chi
+        omega_31 = g1 * eigs_K - ((batch + 1.0) / batch) * eigs_K**2 * (g1 * g2 + g1**2 * g3)
+        omega_32 = (-g3 + g3 * delta * (2.0 - delta)) * jnp.ones_like(eigs_K)
+        omega_33 = -delta - (g2 - g2 * delta + 2.0 * (1.0 - delta) * g1 * g3) * eigs_K
         omega_3 = jnp.array([omega_31, omega_32, omega_33])
 
         omega = jnp.array([omega_1, omega_2, omega_3])  # 3 x 3 x d
         return omega
 
-    def omega_approximate(time_plus):
-        omega11 = -2.0 * g2(time_plus) * eigs_K
-        omega12 = 0.0 * jnp.ones_like(eigs_K)
-        omega13 = 2.0 * g3(time_plus) * -1.0 * jnp.ones_like(eigs_K)
+    def omega_approximate(time_plus, grad_norm):
+        g1_norm, g3_norm = get_normalization_factors(grad_norm)
+        
+        # Normalize hyperparameters to apply adaptivity
+        g1 = g1_fn(time_plus) / g1_norm
+        g2 = g2_fn(time_plus)
+        g3 = g3_fn(time_plus) / g3_norm
+        delta = delta_fn(time_plus)
+        
+        omega11 = -2.0 * g2 * eigs_K
+        omega12 = jnp.zeros_like(eigs_K)
+        omega13 = -2.0 * g3 * jnp.ones_like(eigs_K)
         omega1 = jnp.array([omega11, omega12, omega13])
 
-        omega21 = 0.0 * jnp.ones_like(eigs_K)
-        omega22 = (-2.0 * delta(time_plus)) * jnp.ones_like(eigs_K)
-        omega23 = 2.0 * g1(time_plus) * eigs_K
+        omega21 = jnp.zeros_like(eigs_K)
+        omega22 = -2.0 * delta * jnp.ones_like(eigs_K)
+        omega23 = 2.0 * g1 * eigs_K
         omega2 = jnp.array([omega21, omega22, omega23])
 
-        omega31 = g1(time_plus) * eigs_K
-        omega32 = -g3(time_plus) * jnp.ones_like(eigs_K)
-        omega33 = -delta(time_plus) - g2(time_plus) * eigs_K
+        omega31 = g1 * eigs_K
+        omega32 = -g3 * jnp.ones_like(eigs_K)
+        omega33 = -delta - g2 * eigs_K
         omega3 = jnp.array([omega31, omega32, omega33])
 
-        omega = jnp.array([omega1, omega2, omega3]) #3 x 3 x d
+        omega = jnp.array([omega1, omega2, omega3])  # 3 x 3 x d
         return omega
 
-    def forcing_term(time_plus):
-      Gamma = jnp.array([( opt_hparams.g2(time_plus)**2 + 2.0 * g1(time_plus) * g2(time_plus) * g3(time_plus) + g1(time_plus)**2 * g3(time_plus)**2 ) / batch,
-                          opt_hparams.g1(time_plus)**2 / batch, (-g1(time_plus) * g2(time_plus) - g1(time_plus)**2 * g3(time_plus)) / batch])
-      return jnp.einsum('i,j->ij', Gamma, inputs.eigs_K)  # 3 x d
-    def forcing_term_approximate(time_plus):
-      Gamma = jnp.array([g2(time_plus)**2 / batch,
-                           g1(time_plus)**2 / batch, 0.0])
-      return jnp.einsum('i,j->ij', Gamma, inputs.eigs_K)  # 3 x d
+    def forcing_term(time_plus, grad_norm):
+        g1_norm, g3_norm = get_normalization_factors(grad_norm)
+        
+        # Normalize hyperparameters to apply adaptivity
+        g1 = g1_fn(time_plus) / g1_norm
+        g2 = g2_fn(time_plus)
+        g3 = g3_fn(time_plus) / g3_norm
+        
+        Gamma = jnp.array([
+            (g2**2 + 2.0 * g1 * g2 * g3 + g1**2 * g3**2) / batch,
+            g1**2 / batch,
+            (-g1 * g2 - g1**2 * g3) / batch
+        ])
+        return jnp.einsum('i,j->ij', Gamma, inputs.eigs_K)  # 3 x d
+    
+    def forcing_term_approximate(time_plus, grad_norm):
+        g1_norm, g3_norm = get_normalization_factors(grad_norm)
+        
+        # Normalize hyperparameters to apply adaptivity
+        g1 = g1_fn(time_plus) / g1_norm
+        g2 = g2_fn(time_plus)
+        
+        Gamma = jnp.array([
+            g2**2 / batch,
+            g1**2 / batch,
+            0.0
+        ])
+        return jnp.einsum('i,j->ij', Gamma, inputs.eigs_K)  # 3 x d
 
     def ode_update(carry, time):
         v, twice_risk = carry
         time_plus = jnp.exp(time + dt)
         time_plus_minus_one = time_plus - 1.0
-        omega = omega_approximate(time_plus_minus_one) if approximate else omega_full(time_plus_minus_one)
+        
+        # Use sqrt(risk) as proxy for gradient norm when adaptive is not None
+        grad_norm = jnp.sqrt(twice_risk / 2.0) if adaptive is not None else 1.0
+        
+        omega = omega_approximate(time_plus_minus_one, grad_norm) if approximate else omega_full(time_plus_minus_one, grad_norm)
         identity = jnp.tensordot(jnp.eye(3), jnp.ones(D), 0)
 
         A = inverse_3x3(identity - (dt * time_plus) * omega)  # 3 x 3 x d
 
-        #Gamma = jnp.array([batch * opt_hparams.g2(time_plus)**2,
-        #                   batch * opt_hparams.g1(time_plus)**2, 0.0])
         z = jnp.einsum('i, j -> ij', jnp.array([1.0, 0.0, 0.0]), eigs_K)
-        #G_lambda = jnp.einsum('i,j->ij', Gamma, inputs.eigs_K)  # 3 x d
 
-        G_lambda = forcing_term_approximate(time_plus_minus_one) if approximate else forcing_term(time_plus_minus_one)
+        G_lambda = forcing_term_approximate(time_plus_minus_one, grad_norm) if approximate else forcing_term(time_plus_minus_one, grad_norm)
         x_temp = v + dt * time_plus * twice_risk_infinity * G_lambda
 
         x = jnp.einsum('ijk, jk -> ik', A, x_temp)

--- a/power_law_rf/ode.py
+++ b/power_law_rf/ode.py
@@ -213,8 +213,8 @@ def ode_resolvent_log_implicit(
         time_plus = jnp.exp(time + dt)
         time_plus_minus_one = time_plus - 1.0
         
-        # Use sqrt(risk) as proxy for gradient norm when adaptive is not None
-        grad_norm = jnp.sqrt(twice_risk / 2.0) if adaptive is not None else 1.0
+        # Use sqrt(twice_risk) as proxy for gradient norm when adaptive is not None
+        grad_norm = jnp.sqrt(twice_risk) if adaptive is not None else 1.0
         
         omega = omega_approximate(time_plus_minus_one, grad_norm) if approximate else omega_full(time_plus_minus_one, grad_norm)
         identity = jnp.tensordot(jnp.eye(3), jnp.ones(D), 0)


### PR DESCRIPTION
The ODEs for adaptive optimizers (Adam, LaProp) have a simple structure that just divides either g3 or g1 by the gradient norm (and we use sqrt(risk) as a proxy for the grad norm). Instead of maintaining separate implementations for each adaptive optimizer, this makes the main ODE code support adaptive options.